### PR TITLE
Do not allow Auction master contract to be initialized or destroyed

### DIFF
--- a/contracts/Auction.sol
+++ b/contracts/Auction.sol
@@ -50,6 +50,7 @@ contract Auction is IAuction {
     }
 
     AuctionStorage public self;
+    bool public isMasterContract;
 
     /// @notice Throws if called by any account other than the auctioneer.
     modifier onlyAuctioneer() {
@@ -60,6 +61,10 @@ contract Auction is IAuction {
         );
 
         _;
+    }
+
+    constructor() {
+        isMasterContract = true;
     }
 
     /// @notice Initializes auction
@@ -78,6 +83,7 @@ contract Auction is IAuction {
         uint256 _amountDesired,
         uint256 _auctionLength
     ) external {
+        require(!isMasterContract, "Can not initialize master contract");
         //slither-disable-next-line incorrect-equality
         require(self.startTime == 0, "Auction already initialized");
         require(_amountDesired > 0, "Amount desired must be greater than zero");
@@ -213,6 +219,7 @@ contract Auction is IAuction {
     /// @dev Delete all storage and destroy the contract. Should only be called
     ///      after an auction has closed.
     function harikari() internal {
+        require(!isMasterContract, "Master contract can not harikari");
         address payable addr = address(uint160(address(self.auctioneer)));
         delete self;
         selfdestruct(addr);

--- a/test/Auction.test.js
+++ b/test/Auction.test.js
@@ -20,11 +20,13 @@ const precision = 0.001 // to mitigate evm delays
 
 describe("Auction", () => {
   let testToken
+  let collateralPool
+  let masterAuction
+
   let owner
   let bidder1
   let bidder2
   let auctioneer
-  let collateralPool
 
   before(async () => {
     const CoveragePoolConstants = await ethers.getContractFactory(
@@ -48,7 +50,7 @@ describe("Auction", () => {
     auctioneer = await Auctioneer.deploy()
     await auctioneer.deployed()
 
-    const masterAuction = await Auction.deploy()
+    masterAuction = await Auction.deploy()
     await masterAuction.deployed()
 
     collateralPool = await CollateralPool.deploy()
@@ -87,6 +89,19 @@ describe("Auction", () => {
             auctionLength
           )
         ).to.be.revertedWith("Auction already initialized")
+      })
+    })
+
+    context("when called on the master contract", () => {
+      it("should revert", async () => {
+        await expect(
+          masterAuction.initialize(
+            auctioneer.address,
+            testToken.address,
+            auctionAmountDesired,
+            auctionLength
+          )
+        ).to.be.revertedWith("Can not initialize master contract")
       })
     })
 


### PR DESCRIPTION
<img alt="" width="50%" src="https://user-images.githubusercontent.com/4712360/116662088-9f22a080-a995-11eb-9359-d68d7d1e6ef4.jpg">

The assumption was that we would initialize `Auction` contract during the
deployment so that it cannot be later done by a third party. This
assumption is brittle though - it is easy to forget and humans do
forget things. Consequences could be tragic. One would be able to
initialize the master contract in a way that would let them call
harikari and destroy the master contract.

From now on, we do not rely on our memory or deployment scripts but on
the contract code. It is not possible to initialize the master contract
and there is an additional fuse in harikari itself, not allowing to destroy
the master contract.

Read more about a similar case here:
https://blog.trailofbits.com/2020/12/16/breaking-aave-upgradeability/

Closes: https://github.com/keep-network/coverage-pools/issues/32