### PR TITLE
Stabilize time-dependent unit tests

### DIFF
--- a/test/helpers/contract-test-helpers.js
+++ b/test/helpers/contract-test-helpers.js
@@ -28,7 +28,8 @@ function pastEvents(receipt, contract, eventName) {
 }
 
 async function increaseTime(time) {
-  await ethers.provider.send("evm_increaseTime", [time])
+  const now = (await ethers.provider.getBlock("latest")).timestamp
+  await ethers.provider.send("evm_setNextBlockTimestamp", [now + time])
   await ethers.provider.send("evm_mine")
 }
 


### PR DESCRIPTION
So far, the time-dependent unit tests used a combination of `evm_increaseTime` and `evm_mine`. The `evm_increaseTime` RPC method receives a number of seconds that will be added to the timestamp of the next block, which is eventually mined by `evm_mine` call. However, this behavior causes occasional test failures as sometimes one additional second is added. This is probably due to some overhead introduced by the `evm_increaseTime` method itself.

To fix that problem, we're switching to the Hardhat's `evm_setNextBlockTimestamp` method, which allows setting an exact timestamp for the next block. We're calculating it by taking the timestamp of the latest block and adding the `time` parameter which determines the time travel delta. This solution looks far more stable as the next block timestamp depends only on the timestamp of the previously mined block.

Some testing has been performed using the following helper script:
```
#!/bin/bash

for i in {1..100}
do
   echo "iteration number $i"

   yarn test
   exit_code=$?

   echo "iteration number $i completed with $exit_code code"

   if [ $exit_code -ne 0 ]; then
    echo "test errored out"
    exit 1
   fi

   sleep 1
done
```
The above script was used to run `yarn test` in a loop. The test set has been limited to the `RewardsPool`'s `earned` subset, which contains a lot of time-dependent tests. Before the fix presented in this PR, the loop failed at `15th` iteration on average. After the change, all `100` iterations pass with success.