### PR TITLE
Move the current RewardsPool implementation to v2

### DIFF
--- a/contracts/v2/RewardsPoolV2.sol
+++ b/contracts/v2/RewardsPoolV2.sol
@@ -72,7 +72,7 @@ abstract contract RewardTokenMinting {
 ///         reward rates. Reward rates allows establishing a way for Governance
 ///         to incentivize different assets to target a particular Collateral
 ///         Pool composition.
-contract RewardPool is RewardTokenMinting {
+contract RewardPoolV2 is RewardTokenMinting {
     // TODO: Add function to update reward rate with a governance delay.
     // TODO: Allow to withdraw rewards based on the amount of reward tokens.
 }

--- a/test/v2/RewardsPoolV2.test.js
+++ b/test/v2/RewardsPoolV2.test.js
@@ -5,7 +5,7 @@ const {
   increaseTime,
 } = require("../helpers/contract-test-helpers")
 
-describe("RewardPool", () => {
+describe("RewardPoolV2", () => {
   const assetPool1 = "0x0000000000000000000000000000000000000001"
   const assetPool2 = "0x0000000000000000000000000000000000000002"
   const assetPool3 = "0x0000000000000000000000000000000000000003"
@@ -13,8 +13,8 @@ describe("RewardPool", () => {
   let pool
 
   beforeEach(async () => {
-    const RewardPool = await ethers.getContractFactory("RewardPool")
-    pool = await RewardPool.deploy()
+    const RewardPoolV2 = await ethers.getContractFactory("RewardPoolV2")
+    pool = await RewardPoolV2.deploy()
     await pool.deployed()
   })
 


### PR DESCRIPTION
The multi-asset `RewardsPool` contract will not be used for the first
release of Coverage Pools. For the first release, we will use a 
single-asset `RewardPool` (to be implemented), so we are storing the
existing `RewardsPool `contract separately, for future development and
use. There is a separate `v2` directory that lets us do not mix v1 and v2
contracts together.