### PR TITLE
Tests reorg around auctions

### DIFF
--- a/contracts/RiskManagerV1.sol
+++ b/contracts/RiskManagerV1.sol
@@ -36,6 +36,7 @@ contract RiskManagerV1 is Auctioneer {
 
     uint256 public constant DEPOSIT_LIQUIDATION_IN_PROGRESS_STATE = 10;
     uint256 public constant DEPOSIT_LIQUIDATED_STATE = 11;
+    uint256 public auctionLength = 86400; // in sec, hardcoded 24h
     IERC20 public tbtcToken;
 
     // deposit in liquidation => opened coverage pool auction
@@ -73,7 +74,6 @@ contract RiskManagerV1 is Auctioneer {
 
         // TODO: Need to read the market conditions of assets from Uniswap / 1inch
         //       Based on this data the auction length should be adjusted
-        uint256 auctionLength = 86400; // in sec, hardcoded 24h
 
         emit NotifiedLiquidation(depositAddress, msg.sender);
 
@@ -105,6 +105,14 @@ contract RiskManagerV1 is Auctioneer {
         delete auctionsByDepositsInLiquidation[depositAddress];
         //slither-disable-next-line reentrancy-no-eth,reentrancy-benign
         delete depositsInLiquidationByAuctions[address(auction)];
+    }
+
+    // TODO: we already have PR opened for auctions length update:
+    // https://github.com/keep-network/coverage-pools/pull/28
+    // The simplified function below is for testing purposes only and the tests that
+    // use it will need to be adjusted accordingly after #28 lands in main.
+    function updateAuctionLength(uint256 _auctionLength) external {
+        auctionLength = _auctionLength;
     }
 
     /// @notice Purchase ETH from signer bonds and withdraw funds to this contract.

--- a/contracts/test/AuctioneerStub.sol
+++ b/contracts/test/AuctioneerStub.sol
@@ -8,16 +8,4 @@ contract AuctioneerStub is Auctioneer {
     /// @dev This fallback function is needed by the `impersonateContract`
     ///      test helper function.
     fallback() external payable {}
-
-    function callCreateAuction(
-        IERC20 tokenAccepted,
-        uint256 amountDesired,
-        uint256 auctionLength
-    ) public {
-        createAuction(tokenAccepted, amountDesired, auctionLength);
-    }
-
-    function callEarlyCloseAuction(Auction auction) public {
-        earlyCloseAuction(auction);
-    }
 }

--- a/contracts/test/TestToken.sol
+++ b/contracts/test/TestToken.sol
@@ -18,4 +18,8 @@ contract TestToken is ERC20 {
     function mint(address _account, uint256 _amount) public {
         _mint(_account, _amount);
     }
+
+    function burn(address account, uint256 amount) public {
+        _burn(account, amount);
+    }
 }

--- a/test/Auctioneer.test.js
+++ b/test/Auctioneer.test.js
@@ -7,16 +7,19 @@ const {
   increaseTime,
 } = require("./helpers/contract-test-helpers")
 
+const { deployMockContract } = require("@ethereum-waffle/mock-contract")
 const AuctionJSON = require("../artifacts/contracts/Auction.sol/Auction.json")
+const IDeposit = require("../artifacts/contracts/RiskManagerV1.sol/IDeposit.json")
 
 const auctionLength = 86400 // 24h in sec
 const auctionAmountDesired = to1e18(1) // ex. 1 TBTC
 const testTokensToMint = to1e18(1)
+const depositLiquidationInProgressState = 10
+const depositLiquidatedState = 11
 
 describe("Auctioneer", () => {
   let owner
   let bidder
-  let auctioneer
   let masterAuction
   let collateralPoolStub
   let testToken
@@ -31,7 +34,6 @@ describe("Auctioneer", () => {
     const coveragePoolConstants = await CoveragePoolConstants.deploy()
     await coveragePoolConstants.deployed()
 
-    const Auctioneer = await ethers.getContractFactory("AuctioneerStub")
     const TestToken = await ethers.getContractFactory("TestToken")
     const Auction = await ethers.getContractFactory("Auction", {
       libraries: {
@@ -42,22 +44,30 @@ describe("Auctioneer", () => {
       "CollateralPoolStub"
     )
 
-    auctioneer = await Auctioneer.deploy()
-    await auctioneer.deployed()
-
     masterAuction = await Auction.deploy()
     await masterAuction.deployed()
 
     collateralPoolStub = await CollateralPoolStub.deploy()
     await collateralPoolStub.deployed()
 
-    await auctioneer.initialize(
+    testToken = await TestToken.deploy()
+    await testToken.deployed()
+
+    const RiskManagerV1 = await ethers.getContractFactory("RiskManagerV1")
+    riskManagerV1 = await RiskManagerV1.deploy(testToken.address)
+    await riskManagerV1.initialize(
       collateralPoolStub.address,
       masterAuction.address
     )
+    await riskManagerV1.deployed()
 
-    testToken = await TestToken.deploy()
-    await testToken.deployed()
+    mockIDeposit = await deployMockContract(owner, IDeposit.abi)
+    await mockIDeposit.mock.currentState.returns(
+      depositLiquidationInProgressState
+    )
+
+    await mockIDeposit.mock.purchaseSignerBondsAtAuction.returns()
+    await mockIDeposit.mock.withdrawFunds.returns()
   })
 
   beforeEach(async () => {
@@ -68,7 +78,7 @@ describe("Auctioneer", () => {
     context("when the auctioneer has been already initialized", () => {
       it("should not be initialized again", async () => {
         await expect(
-          auctioneer.initialize(
+          riskManagerV1.initialize(
             collateralPoolStub.address,
             masterAuction.address
           )
@@ -80,13 +90,13 @@ describe("Auctioneer", () => {
   describe("createAuction", () => {
     before(async () => {
       const receipt = await createAuction()
-      events = pastEvents(receipt, auctioneer, "AuctionCreated")
+      events = pastEvents(receipt, riskManagerV1, "AuctionCreated")
     })
 
     context("when caller is the owner", () => {
       it("should create a new auction", async () => {
         expect(
-          await auctioneer.openAuctions(events[0].args["auctionAddress"])
+          await riskManagerV1.openAuctions(events[0].args["auctionAddress"])
         ).to.equal(true)
       })
 
@@ -108,7 +118,7 @@ describe("Auctioneer", () => {
 
     beforeEach(async () => {
       const receipt = await createAuction()
-      const events = pastEvents(receipt, auctioneer, "AuctionCreated")
+      const events = pastEvents(receipt, riskManagerV1, "AuctionCreated")
       auctionAddress = events[0].args["auctionAddress"]
 
       auction = new ethers.Contract(auctionAddress, AuctionJSON.abi, owner)
@@ -163,7 +173,7 @@ describe("Auctioneer", () => {
         })
 
         it("should emit AuctionOfferTaken event", async () => {
-          let events = pastEvents(receipt1, auctioneer, "AuctionOfferTaken")
+          let events = pastEvents(receipt1, riskManagerV1, "AuctionOfferTaken")
           expect(events.length).to.equal(1)
           expect(events[0].args["auction"]).to.equal(auctionAddress)
           expect(events[0].args["auctionTaker"]).to.equal(bidder.address)
@@ -174,7 +184,7 @@ describe("Auctioneer", () => {
             approximation
           )
 
-          events = pastEvents(receipt2, auctioneer, "AuctionOfferTaken")
+          events = pastEvents(receipt2, riskManagerV1, "AuctionOfferTaken")
           expect(events.length).to.equal(1)
           expect(events[0].args["auction"]).to.equal(auctionAddress)
           expect(events[0].args["auctionTaker"]).to.equal(bidder.address)
@@ -202,11 +212,13 @@ describe("Auctioneer", () => {
           // auction desired amount is 1 * 10^18 of test tokens
           // tokens paid: 1 * 10^18 - 0.6 * 10^18
           // remaining tokens to collect is 0.4 * 10^18, hence the auction cannot be closed yet
-          await expect(takeOfferTx2).to.not.emit(auctioneer, "AuctionClosed")
+          await expect(takeOfferTx2).to.not.emit(riskManagerV1, "AuctionClosed")
         })
 
         it("should not stop tracking the auction", async () => {
-          expect(await auctioneer.openAuctions(auctionAddress)).to.equal(true)
+          expect(await riskManagerV1.openAuctions(auctionAddress)).to.equal(
+            true
+          )
         })
       }
     )
@@ -234,7 +246,7 @@ describe("Auctioneer", () => {
       })
 
       it("should emit AuctionOfferTaken event", async () => {
-        const events = pastEvents(receipt, auctioneer, "AuctionOfferTaken")
+        const events = pastEvents(receipt, riskManagerV1, "AuctionOfferTaken")
         expect(events.length).to.equal(1)
         expect(events[0].args["auction"]).to.equal(auctionAddress)
         expect(events[0].args["auctionTaker"]).to.equal(bidder.address)
@@ -260,12 +272,12 @@ describe("Auctioneer", () => {
       it("should emit AuctionClosed event", async () => {
         // auction was fully paid off and should be closed
         await expect(takeOfferTx)
-          .to.emit(auctioneer, "AuctionClosed")
+          .to.emit(riskManagerV1, "AuctionClosed")
           .withArgs(auctionAddress)
       })
 
       it("should stop tracking the auction", async () => {
-        expect(await auctioneer.openAuctions(auctionAddress)).to.equal(false)
+        expect(await riskManagerV1.openAuctions(auctionAddress)).to.equal(false)
       })
     })
   })
@@ -276,7 +288,7 @@ describe("Auctioneer", () => {
 
     beforeEach(async () => {
       const receipt = await createAuction()
-      const events = pastEvents(receipt, auctioneer, "AuctionCreated")
+      const events = pastEvents(receipt, riskManagerV1, "AuctionCreated")
       auctionAddress = events[0].args["auctionAddress"]
 
       auction = new ethers.Contract(auctionAddress, AuctionJSON.abi, owner)
@@ -288,51 +300,54 @@ describe("Auctioneer", () => {
 
     context("when the auction is still open", () => {
       it("should close the auction", async () => {
-        await auctioneer.connect(bidder).callEarlyCloseAuction(auctionAddress)
+        await mockIDeposit.mock.currentState.returns(depositLiquidatedState)
+        await riskManagerV1
+          .connect(bidder)
+          .notifyLiquidated(mockIDeposit.address)
 
         expect(await auction.isOpen()).to.be.false
       })
 
       it("should emit the auction closed event", async () => {
+        await mockIDeposit.mock.currentState.returns(depositLiquidatedState)
         await expect(
-          auctioneer.connect(bidder).callEarlyCloseAuction(auctionAddress)
+          riskManagerV1.connect(bidder).notifyLiquidated(mockIDeposit.address)
         )
-          .to.emit(auctioneer, "AuctionClosed")
+          .to.emit(riskManagerV1, "AuctionClosed")
           .withArgs(auctionAddress)
       })
 
       it("should no longer track the auction", async () => {
-        await auctioneer.connect(bidder).callEarlyCloseAuction(auctionAddress)
+        await mockIDeposit.mock.currentState.returns(depositLiquidatedState)
+        await riskManagerV1
+          .connect(bidder)
+          .notifyLiquidated(mockIDeposit.address)
 
-        expect(await auctioneer.openAuctions(auctionAddress)).to.be.false
+        expect(await riskManagerV1.openAuctions(auctionAddress)).to.be.false
       })
     })
 
     context("when the auction is already closed", () => {
       it("should revert", async () => {
         await auction.connect(bidder).takeOffer(auctionAmountDesired)
+        await mockIDeposit.mock.currentState.returns(depositLiquidatedState)
 
         await expect(
-          auctioneer.connect(bidder).callEarlyCloseAuction(auctionAddress)
-        ).to.be.revertedWith("Address is not an open auction")
-      })
-    })
-
-    context("when the auction doesn't exist", () => {
-      it("should revert", async () => {
-        await expect(
-          auctioneer
-            .connect(bidder)
-            .callEarlyCloseAuction(await bidder.getAddress())
+          riskManagerV1.connect(bidder).notifyLiquidated(mockIDeposit.address)
         ).to.be.revertedWith("Address is not an open auction")
       })
     })
   })
 
   async function createAuction() {
-    const createAuctionTx = await auctioneer
-      .connect(owner)
-      .callCreateAuction(testToken.address, auctionAmountDesired, auctionLength)
+    await mockIDeposit.mock.currentState.returns(
+      depositLiquidationInProgressState
+    )
+    await mockIDeposit.mock.lotSizeTbtc.returns(auctionAmountDesired)
+    await riskManagerV1.updateAuctionLength(auctionLength)
+    const createAuctionTx = await riskManagerV1.notifyLiquidation(
+      mockIDeposit.address
+    )
 
     return await createAuctionTx.wait()
   }


### PR DESCRIPTION
Previously we had a couple of functions in Auctioneer that were public
types and tests were written against them. However, when we added
RiskMangerV1 and those functions became internal, they became not
visible to tests.
This is a draft to test existing Auctioneer functionality indirectly through
external funtions in RiskMangerV1.