### PR TITLE
Governance should be able to approve risk managers

### DIFF
--- a/contracts/CoveragePool.sol
+++ b/contracts/CoveragePool.sol
@@ -12,8 +12,6 @@ import "@openzeppelin/contracts/math/SafeMath.sol";
 contract CoveragePool is Ownable {
     using SafeMath for uint256;
 
-    uint256 public constant RISK_MANAGER_APPROVAL_TIME_DELAY = 2 weeks;
-
     AssetPool public assetPool;
     IERC20 public collateralToken;
 
@@ -48,7 +46,7 @@ contract CoveragePool is Ownable {
         riskManagerApprovalTimestamps[riskManager] =
             /* solhint-disable-next-line not-rely-on-time */
             block.timestamp +
-            RISK_MANAGER_APPROVAL_TIME_DELAY;
+            CoveragePoolConstants.RISK_MANAGER_GOVERNANCE_DELAY;
     }
 
     /// @notice Seize funds from the coverage pool and put them aside for the
@@ -63,14 +61,11 @@ contract CoveragePool is Ownable {
         external
         onlyApprovedRiskManager
     {
-        uint256 FLOATING_POINT_DIVISOR =
-            CoveragePoolConstants.getFloatingPointDivisor();
-
         uint256 amountToSeize =
             collateralToken
                 .balanceOf(address(assetPool))
                 .mul(portionToSeize)
-                .div(FLOATING_POINT_DIVISOR);
+                .div(CoveragePoolConstants.FLOATING_POINT_DIVISOR);
 
         assetPool.claim(recipient, amountToSeize);
     }

--- a/contracts/CoveragePool.sol
+++ b/contracts/CoveragePool.sol
@@ -39,20 +39,20 @@ contract CoveragePool is Ownable {
         collateralToken = _assetPool.collateralToken();
     }
 
-    /// @notice Begins risk manager approval process
+    /// @notice Begins risk manager approval process.
     /// @dev Can be called only by the contract owner. For a risk manager to be
     /// approved, a call to finalizeRiskManagerApproval must follow (after a
-    /// governance delay)
-    /// @param riskManager Risk manager that will be approved
+    /// governance delay).
+    /// @param riskManager Risk manager that will be approved.
     function beginRiskManagerApproval(address riskManager) external onlyOwner {
         /* solhint-disable-next-line not-rely-on-time */
         riskManagerApprovalTimestamps[riskManager] = block.timestamp;
     }
 
-    /// @notice Finalizes risk manager approval process
+    /// @notice Finalizes risk manager approval process.
     /// @dev Can be called only by the contract owner. Must be proceded with a
     /// call to beginRiskManagerApproval and a governance delay must elapse.
-    /// @param riskManager Risk manager that will be approved
+    /// @param riskManager Risk manager that will be approved.
     function finalizeRiskManagerApproval(address riskManager)
         external
         onlyOwner
@@ -71,12 +71,12 @@ contract CoveragePool is Ownable {
         approvedRiskManagers[riskManager] = true;
     }
 
-    /// @notice Begins risk manager unapproval process
+    /// @notice Begins risk manager unapproval process.
     /// @dev Can be called only by the contract owner. For a risk manager to be
     /// unapproved, a call to finalizeRiskManagerUnapproval must follow (after
     /// a governance delay). Can only be called on a risk manager that is
     /// approved.
-    /// @param riskManager Risk manager that will be unapproved
+    /// @param riskManager Risk manager that will be unapproved.
     function beginRiskManagerUnapproval(address riskManager)
         external
         onlyOwner
@@ -86,10 +86,10 @@ contract CoveragePool is Ownable {
         riskManagerUnapprovalTimestamps[riskManager] = block.timestamp;
     }
 
-    /// @notice Finalizes risk manager unapproval process
+    /// @notice Finalizes risk manager unapproval process.
     /// @dev Can be called only by the contract owner. Must be proceded with a
     /// call to beginRiskManagerUnapproval and a governance delay must elapse.
-    /// @param riskManager Risk manager that will be unapproved
+    /// @param riskManager Risk manager that will be unapproved.
     function finalizeRiskManagerUnapproval(address riskManager)
         external
         onlyOwner
@@ -115,7 +115,7 @@ contract CoveragePool is Ownable {
     ///      function will need to take this divisor into account.
     /// @param recipient Address that will receive the pool's seized funds.
     /// @param portionToSeize Portion of the pool to seize in the range (0, 1]
-    ///        multiplied by FLOATING_POINT_DIVISOR
+    ///        multiplied by FLOATING_POINT_DIVISOR.
     function seizeFunds(address recipient, uint256 portionToSeize)
         external
         onlyApprovedRiskManager

--- a/contracts/CoveragePool.sol
+++ b/contracts/CoveragePool.sol
@@ -9,28 +9,28 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/math/SafeMath.sol";
 
+/// @title CoveragePool
+/// @notice A contract that manages a single asset pool. Handles approving and
+/// unapproving of risk managers and allows them to seize funds from the asset
+/// pool if they are approved.
+/// @dev Coverge pool contract is owned by the governance. Coverage pool is the
+/// owner of the asset pool contract.
 contract CoveragePool is Ownable {
     using SafeMath for uint256;
 
     AssetPool public assetPool;
     IERC20 public collateralToken;
 
-    // Maps risk managers to the timestamp they are considered approved
+    // Currently approved risk managers
+    mapping(address => bool) public approvedRiskManagers;
+    // Timestamps of risk managers whose approvals have been initiated
     mapping(address => uint256) public riskManagerApprovalTimestamps;
+    // Timestamps of risk managers whose unapprovals have been initiated
+    mapping(address => uint256) public riskManagerUnapprovalTimestamps;
 
     /// @notice Throws if called by a risk manager that has not been approved
-    /// or approval time delay has not elapsed
-    /// @dev Risk manager approval delay is already added to approval timestamps
     modifier onlyApprovedRiskManager() {
-        require(
-            riskManagerApprovalTimestamps[msg.sender] > 0,
-            "Risk manager not approved"
-        );
-        require(
-            /* solhint-disable-next-line not-rely-on-time */
-            block.timestamp >= riskManagerApprovalTimestamps[msg.sender],
-            "Approval delay has not elapsed"
-        );
+        require(approvedRiskManagers[msg.sender], "Risk manager not approved");
         _;
     }
 
@@ -39,17 +39,76 @@ contract CoveragePool is Ownable {
         collateralToken = _assetPool.collateralToken();
     }
 
-    /// @notice Approves the given risk manager so that it can withdraw funds
-    /// from the asset pool (after approval delay has elapsed)
-    /// @param riskManager Address of a risk manager to be approved
-    function approveRiskManager(address riskManager) external onlyOwner {
-        riskManagerApprovalTimestamps[riskManager] =
-            /* solhint-disable-next-line not-rely-on-time */
-            block.timestamp +
-            CoveragePoolConstants.RISK_MANAGER_GOVERNANCE_DELAY;
+    /// @notice Begins risk manager approval process
+    /// @dev Can be called only by the contract owner. For a risk manager to be
+    /// approved, a call to finalizeRiskManagerApproval must follow (after a
+    /// governance delay)
+    /// @param riskManager Risk manager that will be approved
+    function beginRiskManagerApproval(address riskManager) external onlyOwner {
+        /* solhint-disable-next-line not-rely-on-time */
+        riskManagerApprovalTimestamps[riskManager] = block.timestamp;
     }
 
-    /// @notice Seize funds from the coverage pool and put them aside for the
+    /// @notice Finalizes risk manager approval process
+    /// @dev Can be called only by the contract owner. Must be proceded with a
+    /// call to beginRiskManagerApproval and a governance delay must elapse.
+    /// @param riskManager Risk manager that will be approved
+    function finalizeRiskManagerApproval(address riskManager)
+        external
+        onlyOwner
+    {
+        require(
+            riskManagerApprovalTimestamps[riskManager] > 0,
+            "Risk manager approval not initiated"
+        );
+        require(
+            /* solhint-disable-next-line not-rely-on-time */
+            block.timestamp.sub(riskManagerApprovalTimestamps[riskManager]) >=
+                CoveragePoolConstants.RISK_MANAGER_GOVERNANCE_DELAY,
+            "Risk manager governance delay has not elapsed"
+        );
+        delete riskManagerApprovalTimestamps[riskManager];
+        approvedRiskManagers[riskManager] = true;
+    }
+
+    /// @notice Begins risk manager unapproval process
+    /// @dev Can be called only by the contract owner. For a risk manager to be
+    /// unapproved, a call to finalizeRiskManagerUnapproval must follow (after
+    /// a governance delay). Can only be called on a risk manager that is
+    /// approved.
+    /// @param riskManager Risk manager that will be unapproved
+    function beginRiskManagerUnapproval(address riskManager)
+        external
+        onlyOwner
+    {
+        require(approvedRiskManagers[riskManager], "Risk manager not approved");
+        /* solhint-disable-next-line not-rely-on-time */
+        riskManagerUnapprovalTimestamps[riskManager] = block.timestamp;
+    }
+
+    /// @notice Finalizes risk manager unapproval process
+    /// @dev Can be called only by the contract owner. Must be proceded with a
+    /// call to beginRiskManagerUnapproval and a governance delay must elapse.
+    /// @param riskManager Risk manager that will be unapproved
+    function finalizeRiskManagerUnapproval(address riskManager)
+        external
+        onlyOwner
+    {
+        require(
+            riskManagerUnapprovalTimestamps[riskManager] > 0,
+            "Risk manager unapproval not initiated"
+        );
+        require(
+            /* solhint-disable-next-line not-rely-on-time */
+            block.timestamp.sub(riskManagerUnapprovalTimestamps[riskManager]) >=
+                CoveragePoolConstants.RISK_MANAGER_GOVERNANCE_DELAY,
+            "Risk manager governance delay has not elapsed"
+        );
+        delete riskManagerUnapprovalTimestamps[riskManager];
+        delete approvedRiskManagers[riskManager];
+    }
+
+    /// @notice Seizes funds from the coverage pool and puts them aside for the
     ///         recipient to withdraw.
     /// @dev portionToSeize value was multiplied by FLOATING_POINT_DIVISOR for
     ///      calculation precision purposes. Further calculations in this

--- a/contracts/CoveragePool.sol
+++ b/contracts/CoveragePool.sol
@@ -15,9 +15,11 @@ contract CoveragePool is Ownable {
     AssetPool public assetPool;
     IERC20 public collateralToken;
 
+    mapping(address => bool) private approvedManagers;
+
     /// @notice Throws if called by a Risk Manager that has not been approved
     modifier onlyApprovedRiskManager() {
-        //TODO: implement check for approved Risk Managers
+        require(approvedManagers[msg.sender], "Risk manager not approved");
         _;
     }
 
@@ -26,8 +28,11 @@ contract CoveragePool is Ownable {
         collateralToken = _assetPool.collateralToken();
     }
 
-    function approveRiskManager() external onlyOwner {
-        //TODO: implement
+    /// @notice Approves the given risk manager so that it can withdraw funds
+    /// from theassetPool
+    /// @param riskManager Address of a risk manager to be approved
+    function approveRiskManager(address riskManager) external onlyOwner {
+        approvedManagers[riskManager] = true;
     }
 
     /// @notice Seize funds from the coverage pool and put them aside for the

--- a/contracts/CoveragePoolConstants.sol
+++ b/contracts/CoveragePoolConstants.sol
@@ -8,6 +8,10 @@ library CoveragePoolConstants {
     // when dealing with floating numbers.
     uint256 public constant FLOATING_POINT_DIVISOR = 1e18;
 
+    // Amount of time that needs to elapse before a risk manager is considered
+    // aproved
+    uint256 public constant RISK_MANAGER_GOVERNANCE_DELAY = 30 days;
+
     // Getter for easy access
     function getFloatingPointDivisor() external pure returns (uint256) {
         return FLOATING_POINT_DIVISOR;

--- a/contracts/CoveragePoolConstants.sol
+++ b/contracts/CoveragePoolConstants.sol
@@ -8,8 +8,8 @@ library CoveragePoolConstants {
     // when dealing with floating numbers.
     uint256 public constant FLOATING_POINT_DIVISOR = 1e18;
 
-    // Amount of time that needs to elapse before a risk manager is considered
-    // aproved
+    // Amount of time that needs to elapse before initiation of
+    // approval/unapproval of a risk manager and finalizing approval/unapproval
     uint256 public constant RISK_MANAGER_GOVERNANCE_DELAY = 30 days;
 
     // Getter for easy access

--- a/test/CoveragePool.test.js
+++ b/test/CoveragePool.test.js
@@ -12,6 +12,7 @@ describe("CoveragePool", () => {
   let underwriter
   let recipient
   let riskManager
+  let thirdParty
 
   beforeEach(async () => {
     // Governance that owns Coverage Pool
@@ -22,6 +23,8 @@ describe("CoveragePool", () => {
     recipient = await ethers.getSigner(3)
     // Risk Manager that will seize funds
     riskManager = await ethers.getSigner(4)
+    // Account that is not authorized to call functions on Coverage Pool
+    thirdParty = await ethers.getSigner(5)
 
     const TestToken = await ethers.getContractFactory("TestToken")
     testToken = await TestToken.deploy()
@@ -64,10 +67,9 @@ describe("CoveragePool", () => {
   describe("beginRiskManagerApproval", () => {
     context("when caller is not the governance", () => {
       it("should revert", async () => {
-        const notGovernance = await ethers.getSigner(5)
         await expect(
           coveragePool
-            .connect(notGovernance)
+            .connect(thirdParty)
             .beginRiskManagerApproval(riskManager.address)
         ).to.be.revertedWith("Ownable: caller is not the owner")
       })
@@ -96,10 +98,9 @@ describe("CoveragePool", () => {
   describe("finalizeRiskManagerApproval", () => {
     context("when caller is not the governance", () => {
       it("should revert", async () => {
-        const notGovernance = await ethers.getSigner(5)
         await expect(
           coveragePool
-            .connect(notGovernance)
+            .connect(thirdParty)
             .finalizeRiskManagerApproval(riskManager.address)
         ).to.be.revertedWith("Ownable: caller is not the owner")
       })
@@ -188,10 +189,9 @@ describe("CoveragePool", () => {
 
       context("when caller is not the governance", () => {
         it("should revert", async () => {
-          const notGovernance = await ethers.getSigner(5)
           await expect(
             coveragePool
-              .connect(notGovernance)
+              .connect(thirdParty)
               .beginRiskManagerUnapproval(riskManager.address)
           ).to.be.revertedWith("Ownable: caller is not the owner")
         })
@@ -234,10 +234,9 @@ describe("CoveragePool", () => {
 
     context("when caller is not the governance", () => {
       it("should revert", async () => {
-        const notGovernance = await ethers.getSigner(5)
         await expect(
           coveragePool
-            .connect(notGovernance)
+            .connect(thirdParty)
             .finalizeRiskManagerUnapproval(riskManager.address)
         ).to.be.revertedWith("Ownable: caller is not the owner")
       })

--- a/test/CoveragePool.test.js
+++ b/test/CoveragePool.test.js
@@ -47,11 +47,7 @@ describe("CoveragePool", () => {
     const coveragePoolConstants = await CoveragePoolConstants.deploy()
     await coveragePoolConstants.deployed()
 
-    const CoveragePool = await ethers.getContractFactory("CoveragePool", {
-      libraries: {
-        CoveragePoolConstants: coveragePoolConstants.address,
-      },
-    })
+    const CoveragePool = await ethers.getContractFactory("CoveragePool")
     coveragePool = await CoveragePool.deploy(assetPool.address)
     await coveragePool.deployed()
 
@@ -110,7 +106,7 @@ describe("CoveragePool", () => {
       context("when approval delay has not elapsed", () => {
         beforeEach(async () => {
           // Wait for less than delay approval time
-          await increaseTime(13 * 24 * 3600)
+          await increaseTime(29 * 24 * 3600)
         })
 
         it("should revert", async () => {
@@ -123,7 +119,7 @@ describe("CoveragePool", () => {
       context("when approval delay has elapsed", () => {
         beforeEach(async () => {
           // Wait for delay approval time
-          await increaseTime(14 * 24 * 3600)
+          await increaseTime(30 * 24 * 3600)
         })
 
         it("transfers seized funds to recipient account", async () => {

--- a/test/CoveragePool.test.js
+++ b/test/CoveragePool.test.js
@@ -87,7 +87,7 @@ describe("CoveragePool", () => {
           .be.false
       })
 
-      it("should store risk manager approval timestamp", async () => {
+      it("should store approval process begin timestamp", async () => {
         expect(
           await coveragePool.riskManagerApprovalTimestamps(riskManager.address)
         ).to.be.above(0)
@@ -148,7 +148,7 @@ describe("CoveragePool", () => {
             .finalizeRiskManagerApproval(riskManager.address)
         })
 
-        it("should remove risk manager timestamp", async () => {
+        it("should remove approval process begin timestamp", async () => {
           expect(
             await coveragePool.riskManagerApprovalTimestamps(
               riskManager.address
@@ -209,7 +209,7 @@ describe("CoveragePool", () => {
             .to.be.true
         })
 
-        it("should store risk manager unapproval timestamp", async () => {
+        it("should store unapproval process begin timestamp", async () => {
           expect(
             await coveragePool.riskManagerUnapprovalTimestamps(
               riskManager.address
@@ -284,7 +284,7 @@ describe("CoveragePool", () => {
             .finalizeRiskManagerUnapproval(riskManager.address)
         })
 
-        it("should remove risk manager timestamp", async () => {
+        it("should remove unapproval process begin timestamp", async () => {
           expect(
             await coveragePool.riskManagerUnapprovalTimestamps(
               riskManager.address

--- a/test/CoveragePool.test.js
+++ b/test/CoveragePool.test.js
@@ -1,5 +1,9 @@
 const { expect } = require("chai")
-const { to1e18, to1ePrecision } = require("./helpers/contract-test-helpers")
+const {
+  to1e18,
+  to1ePrecision,
+  increaseTime,
+} = require("./helpers/contract-test-helpers")
 
 describe("CoveragePool", () => {
   let coveragePool
@@ -62,12 +66,27 @@ describe("CoveragePool", () => {
   })
 
   describe("approveRiskManager", () => {
-    context("when caller is not the owner", () => {
+    context("when caller is not the governance", () => {
       it("should revert", async () => {
-        const notOwner = await ethers.getSigner(5)
+        const notGovernance = await ethers.getSigner(5)
         await expect(
-          coveragePool.connect(notOwner).approveRiskManager(riskManager.address)
+          coveragePool
+            .connect(notGovernance)
+            .approveRiskManager(riskManager.address)
         ).to.be.revertedWith("Ownable: caller is not the owner")
+      })
+    })
+
+    context("when caller is the governance", () => {
+      beforeEach(async () => {
+        await coveragePool
+          .connect(governance)
+          .approveRiskManager(riskManager.address)
+      })
+      it("timestamp of risk manager approval should be stored", async () => {
+        expect(
+          await coveragePool.riskManagerApprovalTimestamps(riskManager.address)
+        ).to.be.above(0)
       })
     })
   })
@@ -84,21 +103,42 @@ describe("CoveragePool", () => {
     context("when caller is an approved Risk Manager", () => {
       beforeEach(async () => {
         await coveragePool
-          .connect(owner)
+          .connect(governance)
           .approveRiskManager(riskManager.address)
       })
 
-      // Portion to seize is 0.345987 (multiplied by 10^18 to save precision)
-      const portionToSeize = to1ePrecision(345987, 12)
-      // Expected amount is 400 * 0.345987 = 138.3948 (multiplied by 10^18)
-      const amountSeized = to1ePrecision(1383948, 14)
-      it("the approved Risk Manager can move funds to any account", async () => {
-        await coveragePool
-          .connect(riskManager)
-          .seizeFunds(recipient.address, portionToSeize)
-        expect(await testToken.balanceOf(recipient.address)).to.be.equal(
-          amountSeized
-        )
+      context("when approval delay has not elapsed", () => {
+        beforeEach(async () => {
+          // Wait for less than delay approval time
+          await increaseTime(13 * 24 * 3600)
+        })
+
+        it("should revert", async () => {
+          await expect(
+            coveragePool.connect(riskManager).seizeFunds(recipient.address, 123)
+          ).to.be.revertedWith("Approval delay has not elapsed")
+        })
+      })
+
+      context("when approval delay has elapsed", () => {
+        beforeEach(async () => {
+          // Wait for delay approval time
+          await increaseTime(14 * 24 * 3600)
+        })
+
+        it("transfers seized funds to recipient account", async () => {
+          // Portion to seize is 0.345987 (multiplied by 10^18 to save precision)
+          const portionToSeize = to1ePrecision(345987, 12)
+          // Expected amount is 400 * 0.345987 = 138.3948 (multiplied by 10^18)
+          const amountSeized = to1ePrecision(1383948, 14)
+
+          await coveragePool
+            .connect(riskManager)
+            .seizeFunds(recipient.address, portionToSeize)
+          expect(await testToken.balanceOf(recipient.address)).to.be.equal(
+            amountSeized
+          )
+        })
       })
     })
   })


### PR DESCRIPTION
This pull requests:
- adds functions for two-stage approving/unapproving of risk managers:
   - `beginRiskManagerApproval`
   - `finalizeRiskManagerApproval`
   - `beginRiskManagerUnapproval`
   - `finalizeRiskManagerUnapproval`
   
 Before the `begin...` and `finalize..` functions a delay of 30 days must elapse.
 Approved risk managers are stored in a mapping.
 Timestamps of initiation of approval/unapproval of a risk manager are also stored in mappings.
 
 Only approved risk managers can seize funds.