### PR TITLE
Update Slither version

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Install Slither
         env:
-          SLITHER_VERSION: 0.7.1
+          SLITHER_VERSION: 0.8.0
         run: pip3 install slither-analyzer==$SLITHER_VERSION
 
       - name: Cache yarn directory

--- a/contracts/CloneFactory.sol
+++ b/contracts/CloneFactory.sol
@@ -49,6 +49,7 @@ contract CloneFactory {
         }
     }
 
+    // slither-disable-next-line dead-code
     function isClone(address target, address query)
         internal
         view


### PR DESCRIPTION
Updated Slither to the latest version to repair failing builds as new version contains several bug fixes and should be more stable.