### PR TITLE
Moved EthAssetPool to the v2 folder

### DIFF
--- a/contracts/v2/EthAssetPool.sol
+++ b/contracts/v2/EthAssetPool.sol
@@ -2,8 +2,8 @@
 
 pragma solidity <0.9.0;
 
-import "./AssetPool.sol";
-import "./UnderwriterToken.sol";
+import "../AssetPool.sol";
+import "../UnderwriterToken.sol";
 
 import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/test/v2/EthAssetPool.test.js
+++ b/test/v2/EthAssetPool.test.js
@@ -1,5 +1,5 @@
 const { expect } = require("chai")
-const { to1e18 } = require("./helpers/contract-test-helpers")
+const { to1e18 } = require("../helpers/contract-test-helpers")
 
 describe("EthAssetPool", () => {
   let ethAssetPool


### PR DESCRIPTION
This PR moves EthAssetPool to the v2 folder, as it is not used in version 1 of Coverage Pools.