### PR TITLE
COV token minting rework: reward compounding and value accrued

### DIFF
--- a/contracts/AssetPool.sol
+++ b/contracts/AssetPool.sol
@@ -70,11 +70,6 @@ contract AssetPool is Ownable {
     /// @dev Before calling this function, underwriter token needs to have the
     ///      required amount accepted to transfer to the asset pool.
     function withdraw(uint256 covAmount) external {
-        // TODO: Implement exit market. All withdrawals from the pool that
-        // accept a fixed delay can do so without a fee. Any underwriter who
-        // wants to withdraw more quickly will forfeit part of their collateral
-        // to the pool, with a fee rate based on their percent ownership of the
-        // pool.
         uint256 covBalance = underwriterToken.balanceOf(msg.sender);
         require(
             covAmount <= covBalance,

--- a/contracts/AssetPool.sol
+++ b/contracts/AssetPool.sol
@@ -75,6 +75,13 @@ contract AssetPool is Ownable {
             covAmount <= covBalance,
             "Underwriter token amount exceeds balance"
         );
+        require(
+            covAmount > 0,
+            "Underwriter token amount must be greater than 0"
+        );
+
+        rewardsPool.withdraw();
+
         uint256 covSupply = underwriterToken.totalSupply();
         uint256 collateralBalance = collateralToken.balanceOf(address(this));
 
@@ -89,10 +96,13 @@ contract AssetPool is Ownable {
     /// @notice Allows the coverage pool to demand coverage from the asset hold
     ///         by this pool and send it to the provided recipient address.
     function claim(address recipient, uint256 amount) external onlyOwner {
+        rewardsPool.withdraw();
         collateralToken.safeTransfer(recipient, amount);
     }
 
     function _deposit(address depositor, uint256 amount) internal {
+        rewardsPool.withdraw();
+
         uint256 covSupply = underwriterToken.totalSupply();
         uint256 collateralBalance = collateralToken.balanceOf(address(this));
 

--- a/contracts/AssetPool.sol
+++ b/contracts/AssetPool.sol
@@ -2,18 +2,19 @@
 
 pragma solidity <0.9.0;
 
-import "./UnderwriterToken.sol";
-
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
 import "@openzeppelin/contracts/math/SafeMath.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
+import "./RewardsPool.sol";
+import "./UnderwriterToken.sol";
+
 /// @title AssetPool
-/// @notice Asset pool is a component of a Coverage Pool. Each Asset Pool
+/// @notice Asset pool is a component of a Coverage Pool. Asset Pool
 ///         accepts a single ERC20 token as collateral, and returns an
 ///         underwriter token. For example, an asset pool might accept deposits
-///         in WETH in return for covETH underwriter tokens. Underwriter tokens
+///         in KEEP in return for covKEEP underwriter tokens. Underwriter tokens
 ///         represent an ownership share in the underlying collateral of the
 ///         Asset Pool.
 contract AssetPool is Ownable {
@@ -24,9 +25,18 @@ contract AssetPool is Ownable {
     IERC20 public collateralToken;
     UnderwriterToken public underwriterToken;
 
-    constructor(IERC20 _collateralToken, UnderwriterToken _underwriterToken) {
+    RewardsPool public rewardsPool;
+
+    constructor(
+        IERC20 _collateralToken,
+        UnderwriterToken _underwriterToken,
+        address rewardManager
+    ) {
         collateralToken = _collateralToken;
         underwriterToken = _underwriterToken;
+
+        rewardsPool = new RewardsPool(_collateralToken, this);
+        rewardsPool.transferOwnership(rewardManager);
     }
 
     /// @notice Accepts the given amount of collateral token as a deposit and

--- a/contracts/AssetPool.sol
+++ b/contracts/AssetPool.sol
@@ -30,13 +30,13 @@ contract AssetPool is Ownable {
     constructor(
         IERC20 _collateralToken,
         UnderwriterToken _underwriterToken,
-        address rewardManager
+        address rewardsManager
     ) {
         collateralToken = _collateralToken;
         underwriterToken = _underwriterToken;
 
         rewardsPool = new RewardsPool(_collateralToken, this);
-        rewardsPool.transferOwnership(rewardManager);
+        rewardsPool.transferOwnership(rewardsManager);
     }
 
     /// @notice Accepts the given amount of collateral token as a deposit and

--- a/test/AssetPool.test.js
+++ b/test/AssetPool.test.js
@@ -1,9 +1,16 @@
 const { expect } = require("chai")
-const { to1e18 } = require("./helpers/contract-test-helpers")
+const {
+  to1e18,
+  increaseTime,
+  to1ePrecision,
+} = require("./helpers/contract-test-helpers")
+
+const RewardsPoolJSON = require("../artifacts/contracts/RewardsPool.sol/RewardsPool.json")
 
 describe("AssetPool", () => {
   let assetPool
   let coveragePool
+  let rewardsPool
 
   let collateralToken
   let underwriterToken
@@ -12,13 +19,12 @@ describe("AssetPool", () => {
   let underwriter2
   let underwriter3
   let underwriter4
-  let underwriter5
-  let underwriter6
 
   let rewardManager
 
-  const assertionPrecision = ethers.BigNumber.from("1000000000000") // 0.000001
-  const collateralTokenInitialBalance = to1e18(100000)
+  const assertionPrecision = ethers.BigNumber.from("10000000000000000") // 0.01
+
+  const underwriterInitialCollateralBalance = to1e18(1000000)
 
   beforeEach(async () => {
     coveragePool = await ethers.getSigner(1)
@@ -42,15 +48,24 @@ describe("AssetPool", () => {
     await assetPool.transferOwnership(coveragePool.address)
     await underwriterToken.transferOwnership(assetPool.address)
 
+    rewardsPoolAddress = await assetPool.rewardsPool()
+    rewardsPool = new ethers.Contract(
+      rewardsPoolAddress,
+      RewardsPoolJSON.abi,
+      rewardManager
+    )
+
+    await collateralToken.mint(rewardManager.address, to1e18(1000000))
+
     const createUnderwriterWithTokens = async (index) => {
       const underwriter = await ethers.getSigner(index)
       await collateralToken.mint(
         underwriter.address,
-        collateralTokenInitialBalance
+        underwriterInitialCollateralBalance
       )
       await collateralToken
         .connect(underwriter)
-        .approve(assetPool.address, collateralTokenInitialBalance)
+        .approve(assetPool.address, underwriterInitialCollateralBalance)
       return underwriter
     }
 
@@ -58,14 +73,12 @@ describe("AssetPool", () => {
     underwriter2 = await createUnderwriterWithTokens(4)
     underwriter3 = await createUnderwriterWithTokens(5)
     underwriter4 = await createUnderwriterWithTokens(6)
-    underwriter5 = await createUnderwriterWithTokens(7)
-    underwriter6 = await createUnderwriterWithTokens(8)
   })
 
   describe("deposit", () => {
     context("when the depositor has not enough collateral tokens", () => {
       it("should revert", async () => {
-        const amount = collateralTokenInitialBalance.add(1)
+        const amount = underwriterInitialCollateralBalance.add(1)
         await expect(
           assetPool.connect(underwriter1).deposit(amount)
         ).to.be.revertedWith("ERC20: transfer amount exceeds balance")
@@ -73,6 +86,32 @@ describe("AssetPool", () => {
     })
 
     context("when the depositor has enough collateral tokens", () => {
+      const depositedUnderwriter1 = to1e18(100)
+      const depositedUnderwriter2 = to1e18(300)
+
+      beforeEach(async () => {
+        await assetPool.connect(underwriter1).deposit(depositedUnderwriter1)
+        await assetPool.connect(underwriter2).deposit(depositedUnderwriter2)
+      })
+
+      it("should transfer deposited amount to the pool", async () => {
+        expect(await collateralToken.balanceOf(assetPool.address)).to.equal(
+          to1e18(400)
+        )
+        expect(
+          await collateralToken.balanceOf(underwriter1.address)
+        ).to.be.equal(
+          underwriterInitialCollateralBalance.sub(depositedUnderwriter1)
+        )
+        expect(
+          await collateralToken.balanceOf(underwriter2.address)
+        ).to.be.equal(
+          underwriterInitialCollateralBalance.sub(depositedUnderwriter2)
+        )
+      })
+    })
+
+    context("when depositing tokens for the first time", () => {
       const depositedUnderwriter1 = to1e18(100)
       const depositedUnderwriter2 = to1e18(300)
       const depositedUnderwriter3 = to1e18(20)
@@ -83,22 +122,7 @@ describe("AssetPool", () => {
         await assetPool.connect(underwriter3).deposit(depositedUnderwriter3)
       })
 
-      it("should transfer deposited amount to the pool", async () => {
-        expect(await collateralToken.balanceOf(assetPool.address)).to.equal(
-          to1e18(420)
-        )
-        expect(
-          await collateralToken.balanceOf(underwriter1.address)
-        ).to.be.equal(collateralTokenInitialBalance.sub(depositedUnderwriter1))
-        expect(
-          await collateralToken.balanceOf(underwriter2.address)
-        ).to.be.equal(collateralTokenInitialBalance.sub(depositedUnderwriter2))
-        expect(
-          await collateralToken.balanceOf(underwriter3.address)
-        ).to.be.equal(collateralTokenInitialBalance.sub(depositedUnderwriter3))
-      })
-
-      it("should mint underwriter tokens", async () => {
+      it("should mint the right amount of underwriter tokens", async () => {
         expect(await underwriterToken.balanceOf(underwriter1.address)).to.equal(
           to1e18(100) // 100 COV minted (first deposit)
         )
@@ -111,7 +135,7 @@ describe("AssetPool", () => {
       })
     })
 
-    context("when deposit already exists", () => {
+    context("when there is already a deposit for the given underwriter", () => {
       const depositedUnderwriter1 = to1e18(100)
       const depositedUnderwriter2 = to1e18(70)
 
@@ -120,42 +144,137 @@ describe("AssetPool", () => {
         await assetPool.connect(underwriter2).deposit(depositedUnderwriter2)
       })
 
-      it("should mint underwriter tokens", async () => {
+      it("should mint more underwriter tokens for underwriter", async () => {
         await assetPool.connect(underwriter1).deposit(depositedUnderwriter1)
         await assetPool.connect(underwriter2).deposit(depositedUnderwriter2)
 
         expect(await underwriterToken.balanceOf(underwriter1.address)).to.equal(
-          to1e18(200) // 100 + 100 = 200 COV
+          to1e18(200) // 100 + 100 = 200
         )
         expect(await underwriterToken.balanceOf(underwriter2.address)).to.equal(
-          to1e18(140) // 70 + 70 = 140 COV
+          to1e18(140) // 70 + 70 = 140
         )
       })
     })
 
-    context("when some collateral tokens were claimed by the pool", () => {
+    context("when there was a claim", () => {
       const depositedUnderwriter1 = to1e18(100)
-      const depositedUnderwriter2 = to1e18(70)
-      const claimedTokens = to1e18(35)
+      const depositedUnderwriter2 = to1e18(50)
+      const depositedUnderwriter3 = to1e18(100)
+      const claim = to1e18(25)
 
       beforeEach(async () => {
         await assetPool.connect(underwriter1).deposit(depositedUnderwriter1)
         await assetPool.connect(underwriter2).deposit(depositedUnderwriter2)
-
-        await assetPool
-          .connect(coveragePool)
-          .claim(coveragePool.address, claimedTokens)
+        await assetPool.connect(coveragePool).claim(coveragePool.address, claim)
+        await assetPool.connect(underwriter3).deposit(depositedUnderwriter3)
       })
 
-      it("should mint underwriter tokens", async () => {
-        await assetPool.connect(underwriter3).deposit(to1e18(20))
+      it("should mint the right amount of underwriter tokens", async () => {
+        expect(await underwriterToken.balanceOf(underwriter1.address)).to.equal(
+          to1e18(100) // 100 COV minted (first deposit)
+        )
+        expect(await underwriterToken.balanceOf(underwriter2.address)).to.equal(
+          to1e18(50) // 50 * 100 / 100 = 50 COV minted
+        )
+        expect(await underwriterToken.balanceOf(underwriter3.address)).to.equal(
+          to1e18(120) // 100 * 150 / 125 = 120 COV minted
+        )
+      })
+    })
+
+    context("when rewards were allocated", () => {
+      const depositedUnderwriter1 = to1e18(100)
+      const depositedUnderwriter2 = to1e18(50)
+
+      const allocatedReward = to1e18(70)
+
+      beforeEach(async () => {
+        await collateralToken
+          .connect(rewardManager)
+          .approve(rewardsPool.address, allocatedReward)
+        await rewardsPool.connect(rewardManager).topUpReward(allocatedReward)
+
+        await assetPool.connect(underwriter1).deposit(depositedUnderwriter1)
+        await increaseTime(86400) // +1 day
+        await assetPool.connect(underwriter2).deposit(depositedUnderwriter2)
+      })
+
+      it("should transfer released rewards to asset pool", async () => {
+        // 70 / 7  = 10 reward tokens released every day
+        // 100 + 10 + 50 = 160
+        expect(
+          await collateralToken.balanceOf(assetPool.address)
+        ).to.be.closeTo(to1e18(160), assertionPrecision)
+      })
+
+      it("should mint the right amount of underwriter tokens", async () => {
+        // 100 COV minted (first deposit)
+        expect(await underwriterToken.balanceOf(underwriter1.address)).to.equal(
+          to1e18(100)
+        )
+        // 50 * 100 / 110 = 45.45(45) COV minted
+        expect(
+          await underwriterToken.balanceOf(underwriter2.address)
+        ).to.be.closeTo("45454545454545454545", assertionPrecision)
+      })
+    })
+  })
+
+  describe("claim", () => {
+    beforeEach(async () => {
+      await assetPool.connect(underwriter1).deposit(to1e18(200))
+    })
+
+    context("when not done by the owner", () => {
+      it("should revert", async () => {
+        await expect(
+          assetPool
+            .connect(underwriter1)
+            .claim(coveragePool.address, to1e18(100))
+        ).to.be.revertedWith("Ownable: caller is not the owner")
+      })
+    })
+
+    context("when done by the owner", () => {
+      it("should transfer claimed tokens to the recipient", async () => {
+        const claimRecipient = await ethers.getSigner(15)
+        await assetPool
+          .connect(coveragePool)
+          .claim(claimRecipient.address, to1e18(90))
+        expect(
+          await collateralToken.balanceOf(claimRecipient.address)
+        ).to.equal(to1e18(90))
+      })
+    })
+
+    context("when rewards were allocated", () => {
+      const allocatedReward = to1e18(70)
+
+      beforeEach(async () => {
+        await collateralToken
+          .connect(rewardManager)
+          .approve(rewardsPool.address, allocatedReward)
+        await rewardsPool.connect(rewardManager).topUpReward(allocatedReward)
+
+        await increaseTime(86400) // +1 day
+      })
+
+      it("should first transfer released rewards to asset pool", async () => {
+        const claimRecipient = await ethers.getSigner(15)
+        // 70 / 7  = 10 reward tokens released every day
+        // 200 + 10 tokens in the asset pool
+        // 205 claimed (more than deposited!), 5 stays in the pool
+        await assetPool
+          .connect(coveragePool)
+          .claim(claimRecipient.address, to1e18(205))
 
         expect(
-          await underwriterToken.balanceOf(underwriter3.address)
-        ).to.be.closeTo(
-          ethers.BigNumber.from("25185185000000000000"), // 20 * 170 / 135 = ~25.185185
-          assertionPrecision
-        )
+          await collateralToken.balanceOf(claimRecipient.address)
+        ).to.equal(to1e18(205))
+        expect(
+          await collateralToken.balanceOf(assetPool.address)
+        ).to.be.closeTo(to1e18(5), assertionPrecision)
       })
     })
   })
@@ -171,11 +290,23 @@ describe("AssetPool", () => {
           .approve(assetPool.address, amount)
       })
 
-      it("should burn underwriter tokens", async () => {
+      it("should burn all underwriter tokens", async () => {
         await assetPool.connect(underwriter1).withdraw(amount)
         expect(await underwriterToken.balanceOf(underwriter1.address)).to.equal(
           0
         )
+      })
+    })
+
+    context("when withdrawing zero of collateral", () => {
+      beforeEach(async () => {
+        await assetPool.connect(underwriter1).deposit(to1e18(120))
+      })
+
+      it("should revert", async () => {
+        await expect(
+          assetPool.connect(underwriter1).withdraw(0)
+        ).to.be.revertedWith("Underwriter token amount must be greater than 0")
       })
     })
 
@@ -189,7 +320,7 @@ describe("AssetPool", () => {
           .approve(assetPool.address, amount)
       })
 
-      it("should burn underwriter tokens", async () => {
+      it("should burn the right amount of underwriter tokens", async () => {
         await assetPool.connect(underwriter1).withdraw(to1e18(20))
         expect(await underwriterToken.balanceOf(underwriter1.address)).to.equal(
           to1e18(100)
@@ -226,8 +357,9 @@ describe("AssetPool", () => {
         await assetPool.connect(underwriter3).deposit(depositedUnderwriter3)
         await assetPool.connect(underwriter4).deposit(depositedUnderwriter4)
 
-        // No tokens were claimed by the coverage pool so the number of COV
-        // minted is equal to the number of tokens deposited.
+        // We can approve the number of tokens equal to the number of tokens
+        // deposited - there were no claims and no rewards were allocated so
+        // those numbers are equal.
         await underwriterToken
           .connect(underwriter1)
           .approve(assetPool.address, depositedUnderwriter1)
@@ -242,215 +374,189 @@ describe("AssetPool", () => {
           .approve(assetPool.address, depositedUnderwriter4)
       })
 
-      it("should let all underwriters withdraw their original collateral token amounts", async () => {
+      it("should let all underwriters withdraw their original collateral amounts", async () => {
         await assetPool.connect(underwriter4).withdraw(depositedUnderwriter4)
         expect(await collateralToken.balanceOf(underwriter4.address)).to.equal(
-          collateralTokenInitialBalance
+          underwriterInitialCollateralBalance
         )
 
         await assetPool.connect(underwriter1).withdraw(depositedUnderwriter1)
         expect(await collateralToken.balanceOf(underwriter1.address)).to.equal(
-          collateralTokenInitialBalance
+          underwriterInitialCollateralBalance
         )
 
         await assetPool.connect(underwriter3).withdraw(depositedUnderwriter3)
         expect(await collateralToken.balanceOf(underwriter3.address)).to.equal(
-          collateralTokenInitialBalance
+          underwriterInitialCollateralBalance
         )
         await assetPool.connect(underwriter2).withdraw(depositedUnderwriter2)
         expect(await collateralToken.balanceOf(underwriter2.address)).to.equal(
-          collateralTokenInitialBalance
+          underwriterInitialCollateralBalance
         )
       })
     })
 
-    context("when pool claimed some collateral tokens", () => {
+    context("when there was a claim", () => {
       const depositedUnderwriter1 = to1e18(100)
-      const depositedUnderwriter2 = to1e18(331)
-      const depositedUnderwriter3 = to1e18(22)
-      const depositedUnderwriter4 = to1e18(5)
-      const depositedUnderwriter5 = to1e18(600)
-      const depositedUnderwriter6 = to1e18(3)
+      const depositedUnderwriter2 = to1e18(50)
+      const depositedUnderwriter3 = to1e18(150)
+      const claim = to1e18(25)
 
       beforeEach(async () => {
-        await assetPool.connect(underwriter1).deposit(depositedUnderwriter1) // 100 COV
-        await assetPool.connect(underwriter2).deposit(depositedUnderwriter2) // 331 COV
-        await assetPool.connect(underwriter3).deposit(depositedUnderwriter3) // 22 COV
-        await assetPool.connect(underwriter4).deposit(depositedUnderwriter4) // 5 COV
-        await assetPool.connect(underwriter5).deposit(depositedUnderwriter5) // 600 COV
-        await assetPool.connect(underwriter6).deposit(depositedUnderwriter6) // 3 COV
-      })
+        await assetPool.connect(underwriter1).deposit(depositedUnderwriter1)
+        await assetPool.connect(underwriter2).deposit(depositedUnderwriter2)
+        await assetPool.connect(underwriter3).deposit(depositedUnderwriter3)
+        await assetPool.connect(coveragePool).claim(coveragePool.address, claim)
 
-      it("should let all underwriters withdraw their collateral tokens proportionally to their pool share", async () => {
-        // 40 collateral tokens are claimed by the coverage pool.
-        await assetPool
-          .connect(coveragePool)
-          .claim(coveragePool.address, to1e18(40))
-
-        // The pool has 1021 collateral tokens now (1061 - 40).
-        // 1061 COV tokens exist. The underwriter has 100 COV tokens.
-        // The underwriter can withdraw 1021 * 100/1061 = ~96.22997172
-        // collateral tokens from the pool.
+        const coverageMintedUnderwriter1 = await underwriterToken.balanceOf(
+          underwriter1.address
+        )
+        const coverageMintedUnderwriter2 = await underwriterToken.balanceOf(
+          underwriter2.address
+        )
+        const coverageMintedUnderwriter3 = await underwriterToken.balanceOf(
+          underwriter3.address
+        )
         await underwriterToken
           .connect(underwriter1)
-          .approve(assetPool.address, depositedUnderwriter1)
-        await assetPool.connect(underwriter1).withdraw(depositedUnderwriter1)
+          .approve(assetPool.address, coverageMintedUnderwriter1)
+        await underwriterToken
+          .connect(underwriter2)
+          .approve(assetPool.address, coverageMintedUnderwriter2)
+        await underwriterToken
+          .connect(underwriter3)
+          .approve(assetPool.address, coverageMintedUnderwriter3)
+        await assetPool
+          .connect(underwriter1)
+          .withdraw(coverageMintedUnderwriter1)
+        await assetPool
+          .connect(underwriter2)
+          .withdraw(coverageMintedUnderwriter2)
+        await assetPool
+          .connect(underwriter3)
+          .withdraw(coverageMintedUnderwriter3)
+      })
+
+      it("should seize collateral proportionally to underwriter shares", async () => {
+        // underwriter 1 has 100/300 share of the pool
+        // underwriter 2 has 50/300 share of the pool
+        // underwriter 3 has 150/300 share of the pool
+        //
+        // they are supposed to take the hit proportionally:
+        //   underwriter 1: -25 * 100/300 = -8.3(3)
+        //   underwriter 2: -25 * 50/300 = -4.16(6)
+        //   underwriter 3: -25 * 150/300 = -12.5
         expect(
           await collateralToken.balanceOf(underwriter1.address)
         ).to.be.closeTo(
-          collateralTokenInitialBalance
-            .sub(depositedUnderwriter1)
-            .add(ethers.BigNumber.from("96229971720000000000")),
+          underwriterInitialCollateralBalance.sub("8333333333333333333"),
           assertionPrecision
         )
-
-        // The pool has 924.77002828 collateral tokens now
-        // (1061 - 40 - 96.22997172). 961 COV tokens exist (1061 - 100).
-        // Three underwriters with a total of 600 + 22 + 3 = 625 COV tokens
-        // withdraw their share. In total, they withdraw
-        // 924.77002828 * 625 / 961 = ~601.43732328
-        // collateral tokens from the pool.
-        await underwriterToken
-          .connect(underwriter5)
-          .approve(assetPool.address, depositedUnderwriter5)
-        await underwriterToken
-          .connect(underwriter3)
-          .approve(assetPool.address, depositedUnderwriter3)
-        await underwriterToken
-          .connect(underwriter6)
-          .approve(assetPool.address, depositedUnderwriter6)
-        await assetPool.connect(underwriter5).withdraw(depositedUnderwriter5)
-        await assetPool.connect(underwriter3).withdraw(depositedUnderwriter3)
-        await assetPool.connect(underwriter6).withdraw(depositedUnderwriter6)
-
-        // 60 collateral tokens are claimed by the coverage pool.
-        await assetPool
-          .connect(coveragePool)
-          .claim(coveragePool.address, to1e18(60))
-
-        // The pool has 263.332705 collateral tokens now
-        // (1061 - 40 - 96.22997172 - 601.43732328 - 60).
-        // 336 COV tokens exist (1061 - 100 - 625). The underwriter has 5 COV
-        // tokens. The underwriter can withdraw 263.332705 * 5/336 = ~3.91864144
-        // collateral tokens from the pool.
-        await underwriterToken
-          .connect(underwriter4)
-          .approve(assetPool.address, depositedUnderwriter4)
-        await assetPool.connect(underwriter4).withdraw(depositedUnderwriter4)
-        expect(
-          await collateralToken.balanceOf(underwriter4.address)
-        ).to.be.closeTo(
-          collateralTokenInitialBalance
-            .sub(depositedUnderwriter4)
-            .add(ethers.BigNumber.from("3918641440000000000")),
-          assertionPrecision
-        )
-
-        // The pool has 259.41406356 collateral tokens now.
-        // (1061 - 40 - 96.22997172 - 601.43732328 - 60 - 3.91864144).
-        // 331 COV tokens exist ((1061 - 100 - 625 - 5). The underwriter has 331
-        // COV tokens. The underwriter can withdraw 259.41406356 collateral
-        // tokens from the pool.
-        await underwriterToken
-          .connect(underwriter2)
-          .approve(assetPool.address, depositedUnderwriter2)
-        await assetPool.connect(underwriter2).withdraw(depositedUnderwriter2)
         expect(
           await collateralToken.balanceOf(underwriter2.address)
         ).to.be.closeTo(
-          collateralTokenInitialBalance
-            .sub(depositedUnderwriter2)
-            .add(ethers.BigNumber.from("259414063560000000000")),
+          underwriterInitialCollateralBalance.sub("4166666666666666666"),
           assertionPrecision
         )
-
-        // Nothing left in the collateral pool
-        expect(await collateralToken.balanceOf(assetPool.address)).to.equal(0)
-      })
-
-      context("when collateral tokens were deposited in the meantime", () => {
-        it("should withdraw underwriter collateral tokens proportionally to their pool share", async () => {
-          // 1061 COV tokens exist and 1061 collateral tokens are deposited in
-          // the pool. 40 collateral tokens are claimed by the pool.
-          await assetPool
-            .connect(coveragePool)
-            .claim(coveragePool.address, to1e18(40))
-
-          // 331 collateral tokens added to the pool
-          // 331 * 1061 / 1021 = 343.96767874 COV minted
-          await assetPool.connect(underwriter2).deposit(depositedUnderwriter2)
-
-          // 3 collateral tokens added to the pool
-          // 3 * 1404.96767874 / 1352 = 3.11753183 COV minted
-          await assetPool.connect(underwriter6).deposit(depositedUnderwriter6)
-
-          // Underwriter has 100/1408.08521057 share of the pool. The pool has 1355
-          // collateral tokens (1061-40+331+3) so the underwriter can claim
-          // 1355 * 100/1408.08521057 = 96.2299717253 tokens.
-          await underwriterToken
-            .connect(underwriter1)
-            .approve(assetPool.address, depositedUnderwriter1)
-          await assetPool.connect(underwriter1).withdraw(depositedUnderwriter1)
-          expect(
-            await collateralToken.balanceOf(underwriter1.address)
-          ).to.be.closeTo(
-            collateralTokenInitialBalance
-              .sub(depositedUnderwriter1)
-              .add(ethers.BigNumber.from("96229971725300000000")),
-            assertionPrecision
-          )
-
-          // 1308.08521057 COV tokens exist and 1258.77002827 collateral tokens are
-          // deposited in the pool. 60 collateral tokens are claimed by the pool.
-          await assetPool
-            .connect(coveragePool)
-            .claim(coveragePool.address, to1e18(60))
-
-          // Underwriter has 674.96767874/1308.08521057 share of the pool and
-          // decides to spend half of it. The pool has 1198.77002827 collateral
-          // tokens so the underwriter claims
-          // 1198.77002827 * 337/1308.08521057 = 308.83729612 tokens.
-          await underwriterToken
-            .connect(underwriter2)
-            .approve(assetPool.address, to1e18(337))
-          await assetPool.connect(underwriter2).withdraw(to1e18(337))
-          expect(
-            await collateralToken.balanceOf(underwriter2.address)
-          ).to.be.closeTo(
-            collateralTokenInitialBalance
-              .sub(depositedUnderwriter2)
-              .sub(depositedUnderwriter2) // deposited twice
-              .add(ethers.BigNumber.from("308837296120000000000")),
-            assertionPrecision
-          )
-        })
-      })
-    })
-  })
-
-  describe("claim", () => {
-    beforeEach(async () => {
-      await assetPool.connect(underwriter1).deposit(to1e18(200))
-    })
-    context("when not done by the owner", () => {
-      it("should revert", async () => {
-        await expect(
-          assetPool
-            .connect(underwriter1)
-            .claim(coveragePool.address, to1e18(100))
-        ).to.be.revertedWith("Ownable: caller is not the owner")
-      })
-    })
-
-    context("when done by the owner", () => {
-      it("should transfer claimed tokens to the recipient", async () => {
-        const claimRecipient = await ethers.getSigner(15)
-        await assetPool
-          .connect(coveragePool)
-          .claim(claimRecipient.address, to1e18(90))
         expect(
-          await collateralToken.balanceOf(claimRecipient.address)
-        ).to.equal(to1e18(90))
+          await collateralToken.balanceOf(underwriter3.address)
+        ).to.be.closeTo(
+          underwriterInitialCollateralBalance.sub("12500000000000000000"),
+          assertionPrecision
+        )
+      })
+    })
+
+    context("when rewards were allocated", () => {
+      const depositedUnderwriter1 = to1e18(100)
+      const depositedUnderwriter2 = to1e18(300)
+      const depositedUnderwriter3 = to1e18(50)
+
+      const allocatedReward = to1e18(70)
+
+      beforeEach(async () => {
+        await collateralToken
+          .connect(rewardManager)
+          .approve(rewardsPool.address, allocatedReward)
+        await rewardsPool.connect(rewardManager).topUpReward(allocatedReward)
+
+        await assetPool.connect(underwriter1).deposit(depositedUnderwriter1)
+        await increaseTime(86400) // +1 day
+        await assetPool.connect(underwriter2).deposit(depositedUnderwriter2)
+        await increaseTime(86400) // +1 day
+        await assetPool.connect(underwriter3).deposit(depositedUnderwriter3)
+        await increaseTime(86400) // +1 day
+
+        const coverageMintedUnderwriter1 = await underwriterToken.balanceOf(
+          underwriter1.address
+        )
+        const coverageMintedUnderwriter2 = await underwriterToken.balanceOf(
+          underwriter2.address
+        )
+        const coverageMintedUnderwriter3 = await underwriterToken.balanceOf(
+          underwriter3.address
+        )
+
+        await underwriterToken
+          .connect(underwriter1)
+          .approve(assetPool.address, coverageMintedUnderwriter1)
+        await underwriterToken
+          .connect(underwriter2)
+          .approve(assetPool.address, coverageMintedUnderwriter2)
+        await underwriterToken
+          .connect(underwriter3)
+          .approve(assetPool.address, coverageMintedUnderwriter3)
+
+        await assetPool
+          .connect(underwriter1)
+          .withdraw(coverageMintedUnderwriter1)
+        await assetPool
+          .connect(underwriter2)
+          .withdraw(coverageMintedUnderwriter2)
+        await assetPool
+          .connect(underwriter3)
+          .withdraw(coverageMintedUnderwriter3)
+      })
+
+      it("should withdraw collateral and released rewards", async () => {
+        // day 1:
+        //   +10 tokens to underwriter 1
+        //
+        // day 2:
+        //   110 / 410 * 10 = +2.6829268293 tokens to underwriter 1
+        //   300 / 410 * 10 = +7.3170731707 tokens to underwriter 2
+        //
+        // day 3:
+        //   112.6829268293 / 470 * 10 = +2.3975090815 tokens to underwriter 1
+        //   307.3170731707 / 470 * 10 = +6.5386611313 tokens to underwriter 2
+        //         50 / 470 * 10 = +1.0638297872 tokens to underwriter 3
+        //
+        // earned:
+        //    underwriter 1: 10 + 2.6829268293 + 2.3975090815 = 15.0804359108
+        //    underwriter 2:      7.3170731707 + 6.5386611313 = 13.855734302
+        //    underwriter 3:                                     1.0638297872
+        const expectedEarnedUnderwriter1 = to1ePrecision(1508, 16)
+        const expectedEarnedUnderwriter2 = to1ePrecision(1385, 16)
+        const expectedEarnedUnderwriter3 = to1ePrecision(106, 16)
+
+        expect(
+          await collateralToken.balanceOf(underwriter1.address)
+        ).to.be.closeTo(
+          underwriterInitialCollateralBalance.add(expectedEarnedUnderwriter1),
+          assertionPrecision
+        )
+        expect(
+          await collateralToken.balanceOf(underwriter2.address)
+        ).to.be.closeTo(
+          underwriterInitialCollateralBalance.add(expectedEarnedUnderwriter2),
+          assertionPrecision
+        )
+        expect(
+          await collateralToken.balanceOf(underwriter3.address)
+        ).to.be.closeTo(
+          underwriterInitialCollateralBalance.add(expectedEarnedUnderwriter3),
+          assertionPrecision
+        )
       })
     })
   })

--- a/test/AssetPool.test.js
+++ b/test/AssetPool.test.js
@@ -15,11 +15,14 @@ describe("AssetPool", () => {
   let underwriter5
   let underwriter6
 
+  let rewardManager
+
   const assertionPrecision = ethers.BigNumber.from("1000000000000") // 0.000001
   const collateralTokenInitialBalance = to1e18(100000)
 
   beforeEach(async () => {
-    coveragePool = await ethers.getSigner(7)
+    coveragePool = await ethers.getSigner(1)
+    rewardManager = await ethers.getSigner(2)
 
     const TestToken = await ethers.getContractFactory("TestToken")
     collateralToken = await TestToken.deploy()
@@ -32,7 +35,8 @@ describe("AssetPool", () => {
     const AssetPool = await ethers.getContractFactory("AssetPool")
     assetPool = await AssetPool.deploy(
       collateralToken.address,
-      underwriterToken.address
+      underwriterToken.address,
+      rewardManager.address
     )
     await assetPool.deployed()
     await assetPool.transferOwnership(coveragePool.address)
@@ -50,12 +54,12 @@ describe("AssetPool", () => {
       return underwriter
     }
 
-    underwriter1 = await createUnderwriterWithTokens(1)
-    underwriter2 = await createUnderwriterWithTokens(2)
-    underwriter3 = await createUnderwriterWithTokens(3)
-    underwriter4 = await createUnderwriterWithTokens(4)
-    underwriter5 = await createUnderwriterWithTokens(5)
-    underwriter6 = await createUnderwriterWithTokens(6)
+    underwriter1 = await createUnderwriterWithTokens(3)
+    underwriter2 = await createUnderwriterWithTokens(4)
+    underwriter3 = await createUnderwriterWithTokens(5)
+    underwriter4 = await createUnderwriterWithTokens(6)
+    underwriter5 = await createUnderwriterWithTokens(7)
+    underwriter6 = await createUnderwriterWithTokens(8)
   })
 
   describe("deposit", () => {

--- a/test/CoveragePool.test.js
+++ b/test/CoveragePool.test.js
@@ -18,6 +18,8 @@ describe("CoveragePool", () => {
     recipient = await ethers.getSigner(3)
     // Risk Manager that will be approved
     approvedRiskManager = await ethers.getSigner(4)
+    // Account funding Asset Pool with rewards
+    const rewardsManager = await ethers.getSigner(5)
 
     const TestToken = await ethers.getContractFactory("TestToken")
     testToken = await TestToken.deploy()
@@ -33,7 +35,8 @@ describe("CoveragePool", () => {
     const AssetPool = await ethers.getContractFactory("AssetPool")
     const assetPool = await AssetPool.deploy(
       testToken.address,
-      underwriterToken.address
+      underwriterToken.address,
+      rewardsManager.address
     )
     await assetPool.deployed()
 

--- a/test/v2/EthAssetPool.test.js
+++ b/test/v2/EthAssetPool.test.js
@@ -20,10 +20,12 @@ describe("EthAssetPool", () => {
     underwriterToken = await UnderwriterToken.deploy("Underwriter Token", "COV")
     await underwriterToken.deployed()
 
+    const rewardManager = await ethers.getSigner(1)
     const AssetPool = await ethers.getContractFactory("AssetPool")
     wethAssetPool = await AssetPool.deploy(
       wethToken.address,
-      underwriterToken.address
+      underwriterToken.address,
+      rewardManager.address
     )
     await wethAssetPool.deployed()
     await underwriterToken.transferOwnership(wethAssetPool.address)
@@ -35,9 +37,9 @@ describe("EthAssetPool", () => {
     )
     await ethAssetPool.deployed()
 
-    underwriter1 = await ethers.getSigner(1)
-    underwriter2 = await ethers.getSigner(2)
-    underwriter3 = await ethers.getSigner(3)
+    underwriter1 = await ethers.getSigner(2)
+    underwriter2 = await ethers.getSigner(3)
+    underwriter3 = await ethers.getSigner(4)
   })
 
   describe("deposit", () => {


### PR DESCRIPTION
Before reviewing this code, please get familiar with how v1 rewards are released in https://github.com/keep-network/coverage-pools/pull/41.

From now on, Asset Pool creates a Rewards Pool. 
There is an egg and chicken problem between Asset Pool and Rewards Pool.
Rewards Pool needs to transfer rewards only to Asset Pool and Asset Pool
needs to know the address of Rewards Pool so that it can pull rewards
during deposit and withdrawal. The setup in which Asset Pool creates
Rewards Pool seems to be the best one given that reward token needs to be
the same as the collateral token.

Before coverage is deposited by underwriters, before it is claimed by coverage
pool, and before underwriters withdraw their coverage, Asset Pool withdraws
unlocked rewards from the Rewards Pool.

This way, Asset Pool can adjust the number of COV minted so that new
depositors are not participating in rewards accrued by the pool before they
joined:

COV_toMint / COV_totalSupply = collateral_toDeposit / collateral_totalDeposited
COV_toMint = collateral_toDeposit * COV_totalSupply / collateral_totalDeposited

Rewards unlocked by the Rewards Pool are "autocompounding" for the Asset Pool
underwriters.

SCENARIO 1
----------

70k KEEP allocated as a weekly reward.
Three underwriters depositing roughly at the same time:
- underwriter 1: 150k KEEP
- underwriter 2: 50k KEEP
- underwriter 3: 200k KEEP

After four days, 40k KEEP rewards unlocked and all three underwriters are
withdrawing from the pool.

They will earn:
- underwriter 1: 15k KEEP
- underwriter 2: 5k KEEP
- underwriter 3: 20k KEEP

EXPLANATION

- Underwriter 1 has 150/400 share of the pool (150k out of 400k COV tokens).
  They can claim 150/400 rewards unlocked: 150 / 400 * 40k = 15k.
- Underwriter 2 has 50/400 share of the pool. (50k out of 400k COV tokens).
  They can claim 50/400 rewards unlocked: 50 / 400 * 40k = 5k.
- Underwriter 3 has 200/400 share of the pool. (200k out of 400k COV tokens).
  They can claim 200/400 rewards unlocked: 200/400 * 40k = 20k.

SCENARIO 2
----------

70k KEEP allocated as a weekly reward.
Underwriter 1 depositing 150k KEEP
Underwriter 2 depositing 50k KEEP after 24 hours.
Underwriter 3 depositing 200k KEEP after 24 hours.
24 hours passes, all three underwriters are withdrawing from the pool.

They will earn:
- underwriter 1: ~21610 KEEP
- underwriter 2: ~3627 KEEP
- underwriter 3: ~4761 KEEP

EXPLANATION:

Underwriter 1 is depositing. They receive 150k COV tokens.

For the first day, underwriter 1 is the only one in the pool.
They earn 70k / 7 = 10k KEEP.

Underwriter 2 is depositing. 150k + 10k KEEP is in the pool now (deposited
and rewarded). We need to adjust the amount of COV tokens minted for
underwriter 2 so that they do not take a share of rewards accrued by the pool
so far. COV_minted = 50k * 150k / 160k = 46.87k.

There are two underwriters in the pool now and they earn reward proportionally
to their share:
- underwriter 1: 150 / 196.87 * 10k = 7 619.24 KEEP.
- underwriter 2: 46.87 / 196.87 * 10k = 2 380.75 KEEP

Underwriter 3 is depositing. 150k + 10k + 50k + 10k is in the pool now
(deposited and rewarded). We need to adjust the amount of COV tokens minted
for underwriter 3 so that they do not take a share of rewards accrued by the
pool so far. COV_minted = 200k * 196.87k / 220k = 178.97k.

There are three underwriters in the pool now and they earn reward proportionally
to their share:
- underwriter 1: 150 / 375.84 * 10k = 3 991.06 KEEP.
- underwriter 2: 46.87 / 375.84 * 10k = 1 247.07 KEEP.
- underwriter 3: 178.97 / 375.84 * 10k = 4 761.86 KEEP.

In total, underwriters earned:
- underwriter 1: 10k + 7619.24 + 3991.06 = 21 610.3 KEEP
- underwriter 2: 2380.75 + 1247.07 = 3 627.82 KEEP
- underwriter 3: 4 761.86 KEEP

SCENARIO 3
----------

This scenario is an extension of SCENARIO 2 with an additional claim for
50k KEEP tokens from the coverage pool at the end.

There is 430k KEEP in the pool (deposited + rewards).

Underwriter 1 has 150 / 375.84 = 0.399 of the pool (= (150k + 21 610) / 430k))
Underwriter 2 has 46.87 / 375.84 = 0.124 of the pool (= (50k + 3 627) / 430k))
Underwriter 3 has 178.97 / 375.84 = 0.476 of the pool (= (200k + 4 761) / 430k))

The coverage pool claims 50k KEEP and all underwriters withdraw their funds
right after. In this scenario, they will earn/lose:

- underwriter 1:  1 655 KEEP
- underwriter 2: -2 608 KEEP
- underwriter 3: -19 048 KEEP

EXPLANATION:

Coverage pool loses 50k KEEP. Underwriters are expected to take a hit
proportionally to their share of the pool:
- underwriter 1: -50k * 150 / 375.84 = -19 955 KEEP
- underwriter 2: -50k * 46.87 / 375.84 = -50k * 0.124 = -6 235 KEEP
- underwriter 3: -50k * 178.97 / 375.84 = -50k * 0.476 = -23 809 KEEP

In total, underwriters earned/lost:
- underwriter 1: 21 610 - 19 955  = 1 655 KEEP
- underwriter 2: 3 627 - 6 235 = -2 608 KEEP
- underwriter 3: 4 761 - 23 809 = -19 048 KEEP