### PR TITLE
Explained two-week withdrawal period in v1 documentation

### DIFF
--- a/docs/design.adoc
+++ b/docs/design.adoc
@@ -84,7 +84,19 @@ positions at any time with no initialization period.
 
 There is a fixed, non-governable, two-week withdrawal period for underwriters.
 During this period, underwriters are earning rewards but their positions are
-also a subject of potential claims of the risk manager.
+also a subject of potential claims from the risk manager. Such a delay is needed
+so that malicious underwriters can not trick the system by withdrawing their
+positions immediately, just before the claim from the risk manager.
+
+It takes 14 days at minimum for the underwriter to withdraw their collateral and
+rewards. After 14 days from initiating the withdrawal, the underwriter has 7
+days to complete the withdrawal. After 7 days, graceful withdrawal timeout
+passes and part of underwriter's rewards and collateral is slowly getting seized
+by the pool - more and more over the time. Seizing is needed to avoid malicious
+underwriters free-riding the pool - being able to exit at any moment and still
+earning rewards. After additional 60 days (70 days from the time withdrawal
+delay passed), 99% of tokens is seized by the pool and 1% of tokens is sent
+to the notifier who completed the withdrawal on behalf of the underwriter.
 
 Before asset pool balance sheet changes during deposit, withdrawal, or claim
 operations, asset pool withdraws unlocked rewards from the rewards pool.

--- a/docs/design.adoc
+++ b/docs/design.adoc
@@ -94,7 +94,7 @@ days to complete the withdrawal. After 7 days, graceful withdrawal timeout
 passes and part of underwriter's rewards and collateral is slowly getting seized
 by the pool - more and more over the time. Seizing is needed to avoid malicious
 underwriters free-riding the pool - being able to exit at any moment and still
-earning rewards. After additional 60 days (70 days from the time withdrawal
+earning rewards. After additional 63 days (70 days from the time withdrawal
 delay passed), 99% of tokens is seized by the pool and 1% of tokens is sent
 to the notifier who completed the withdrawal on behalf of the underwriter.
 


### PR DESCRIPTION
Explained two-week withdrawal period, as implemented in https://github.com/keep-network/coverage-pools/pull/56.