### PR TITLE
Fix for audit issue "Withdrawal that reached the timeout can be reset"

### DIFF
--- a/test/AssetPool.test.js
+++ b/test/AssetPool.test.js
@@ -370,16 +370,15 @@ describe("AssetPool", () => {
           await assetPool
             .connect(underwriter1)
             .initiateWithdrawal(amount.sub(10))
-          // wait for 21 days (14 days for withdrawal delay and 7 days for
-          // graceful withdrawal timeout)
-          await increaseTime(1814400)
+          // wait for 14 days for withdrawal delay to pass
+          await increaseTime(14 * 24 * 3600)
         })
 
         it("should revert", async () => {
           await expect(
             assetPool.connect(underwriter1).initiateWithdrawal(10)
           ).to.be.revertedWith(
-            "Cannot initiate withdrawal after graceful withdrawal timeout"
+            "Cannot initiate withdrawal after withdrawal delay"
           )
         })
       }

--- a/test/AssetPool.test.js
+++ b/test/AssetPool.test.js
@@ -362,6 +362,28 @@ describe("AssetPool", () => {
           .withArgs(underwriter1.address, amount, await lastBlockTime())
       })
     })
+
+    context(
+      "when there was a pending withdrawal and graceful withdrawal timeout has elapsed",
+      () => {
+        beforeEach(async () => {
+          await assetPool
+            .connect(underwriter1)
+            .initiateWithdrawal(amount.sub(10))
+          // wait for 21 days (14 days for withdrawal delay and 7 days for
+          // graceful withdrawal timeout)
+          await increaseTime(1814400)
+        })
+
+        it("should revert", async () => {
+          await expect(
+            assetPool.connect(underwriter1).initiateWithdrawal(10)
+          ).to.be.revertedWith(
+            "Cannot initiate withdrawal after graceful withdrawal timeout"
+          )
+        })
+      }
+    )
   })
 
   describe("completeWithdrawal", () => {


### PR DESCRIPTION
Closes: #60 

This pull requests addresses an issue reported during the audit: [Withdrawal that reached the timeout can be reset](https://github.com/keep-network/coverage-pools/issues/60).

Eve can `initiateWithdrawal` one more time but only during the withdrawal delay. This action will reset the withdrawal clock. Each `initiateWithdrawal` call increases the amount Eve will eventually withdraw from the pool, i.e. initiated withdrawals sum up.

This way, Eve can decide to reduce her position in the pool even more without having to wait for the remaining time of the withdrawal delay to complete the pending withdrawal and then, waiting for the entire withdrawal delay again. At the same time, we do not leave room for manipulation and we keep the mechanism simple.