### PR TITLE
Implemented logic for updating signer bonds swap strategy in Risk Manager

### DIFF
--- a/contracts/RiskManagerV1.sol
+++ b/contracts/RiskManagerV1.sol
@@ -64,8 +64,9 @@ contract RiskManagerV1 is Auctioneer, Ownable {
 
     IERC20 public tbtcToken;
 
-    // TODO: should be possible to change by the governance.
     ISignerBondsSwapStrategy public signerBondsSwapStrategy;
+    ISignerBondsSwapStrategy public newSignerBondsSwapStrategy;
+    uint256 public signerBondsSwapStrategyInitiated;
 
     // deposit in liquidation => opened coverage pool auction
     mapping(address => address) public depositToAuction;
@@ -83,6 +84,14 @@ contract RiskManagerV1 is Auctioneer, Ownable {
         uint256 timestamp
     );
     event CollateralizationThresholdUpdated(uint256 collateralizationThreshold);
+
+    event SignerBondsSwapStrategyUpdateStarted(
+        address indexed signerBondsSwapStrategy,
+        uint256 timestamp
+    );
+    event SignerBondsSwapStrategyUpdated(
+        address indexed signerBondsSwapStrategy
+    );
 
     /// @notice Reverts if called before the delay elapses.
     /// @param changeInitiatedTimestamp Timestamp indicating the beginning
@@ -213,8 +222,8 @@ contract RiskManagerV1 is Auctioneer, Ownable {
     }
 
     /// @notice Finalizes the auction length update process.
-    /// @dev Can be called only by the contract owner, after the the
-    ///      governance delay elapses.
+    /// @dev Can be called only by the contract owner, after the governance
+    ///      delay elapses.
     function finalizeAuctionLengthUpdate()
         external
         onlyOwner
@@ -224,6 +233,39 @@ contract RiskManagerV1 is Auctioneer, Ownable {
         emit AuctionLengthUpdated(newAuctionLength);
         newAuctionLength = 0;
         auctionLengthChangeInitiated = 0;
+    }
+
+    /// @notice Begins the signer bonds swap strategy update process.
+    /// @dev Must be followed by a finalizeSignerBondsSwapStrategyUpdate after
+    ///      the governance delay elapses.
+    /// @param _newSignerBondsSwapStrategy The new signer bonds swap strategy.
+    function beginSignerBondsSwapStrategyUpdate(
+        ISignerBondsSwapStrategy _newSignerBondsSwapStrategy
+    ) external onlyOwner {
+        newSignerBondsSwapStrategy = _newSignerBondsSwapStrategy;
+        /* solhint-disable-next-line not-rely-on-time */
+        signerBondsSwapStrategyInitiated = block.timestamp;
+        emit SignerBondsSwapStrategyUpdateStarted(
+            address(_newSignerBondsSwapStrategy),
+            /* solhint-disable-next-line not-rely-on-time */
+            block.timestamp
+        );
+    }
+
+    /// @notice Finalizes the signer bonds swap strategy update.
+    /// @dev Can be called only by the contract owner, after the governance
+    ///      delay elapses.
+    function finalizeSignerBondsSwapStrategyUpdate()
+        external
+        onlyOwner
+        onlyAfterGovernanceDelay(signerBondsSwapStrategyInitiated)
+    {
+        signerBondsSwapStrategy = newSignerBondsSwapStrategy;
+        emit SignerBondsSwapStrategyUpdated(
+            address(newSignerBondsSwapStrategy)
+        );
+        delete newSignerBondsSwapStrategy;
+        signerBondsSwapStrategyInitiated = 0;
     }
 
     /// @notice Get the time remaining until the collateralization threshold
@@ -252,6 +294,21 @@ contract RiskManagerV1 is Auctioneer, Ownable {
         return
             getRemainingChangeTime(
                 auctionLengthChangeInitiated,
+                GOVERNANCE_TIME_DELAY
+            );
+    }
+
+    /// @notice Get the time remaining until the signer bonds swap strategy
+    ///         can be changed.
+    /// @return Remaining time in seconds.
+    function getRemainingSignerBondsSwapStrategyChangeTime()
+        external
+        view
+        returns (uint256)
+    {
+        return
+            getRemainingChangeTime(
+                signerBondsSwapStrategyInitiated,
                 GOVERNANCE_TIME_DELAY
             );
     }

--- a/contracts/RiskManagerV1.sol
+++ b/contracts/RiskManagerV1.sol
@@ -242,6 +242,10 @@ contract RiskManagerV1 is Auctioneer, Ownable {
     function beginSignerBondsSwapStrategyUpdate(
         ISignerBondsSwapStrategy _newSignerBondsSwapStrategy
     ) external onlyOwner {
+        require(
+            address(_newSignerBondsSwapStrategy) != address(0),
+            "Invalid signer bonds swap strategy address"
+        );
         newSignerBondsSwapStrategy = _newSignerBondsSwapStrategy;
         /* solhint-disable-next-line not-rely-on-time */
         signerBondsSwapStrategyInitiated = block.timestamp;

--- a/test/RiskManagerV1.test.js
+++ b/test/RiskManagerV1.test.js
@@ -35,6 +35,10 @@ describe("RiskManagerV1", () => {
     signerBondsSwapStrategy = await SignerBondsSwapStrategy.deploy()
     await signerBondsSwapStrategy.deployed()
 
+    // TODO: Another type of strategy could be used
+    anotherSignerBondsSwapStrategy = await SignerBondsSwapStrategy.deploy()
+    await anotherSignerBondsSwapStrategy.deployed()
+
     const Auction = await ethers.getContractFactory("Auction")
     const CoveragePoolStub = await ethers.getContractFactory("CoveragePoolStub")
     const coveragePoolStub = await CoveragePoolStub.deploy()
@@ -388,6 +392,133 @@ describe("RiskManagerV1", () => {
           riskManagerV1
             .connect(owner)
             .finalizeCollateralizationThresholdUpdate()
+        ).to.be.revertedWith("Change not initiated")
+      })
+    })
+  })
+
+  describe("beginSignerBondsSwapStrategyUpdate", () => {
+    context("when the caller is the owner", () => {
+      let tx
+      beforeEach(async () => {
+        tx = await riskManagerV1
+          .connect(owner)
+          .beginSignerBondsSwapStrategyUpdate(
+            anotherSignerBondsSwapStrategy.address
+          )
+      })
+
+      it("should not update the signerBondsSwapStrategy", async () => {
+        expect(await riskManagerV1.signerBondsSwapStrategy()).to.be.equal(
+          signerBondsSwapStrategy.address
+        )
+      })
+
+      it("should start the governance delay timer", async () => {
+        expect(
+          await riskManagerV1.getRemainingSignerBondsSwapStrategyChangeTime()
+        ).to.be.equal(43200) // 12h contract governance delay
+      })
+
+      it("should emit the SignerBondsSwapStrategyUpdateStarted event", async () => {
+        const blockTimestamp = (await ethers.provider.getBlock(tx.blockNumber))
+          .timestamp
+        await expect(tx)
+          .to.emit(riskManagerV1, "SignerBondsSwapStrategyUpdateStarted")
+          .withArgs(anotherSignerBondsSwapStrategy.address, blockTimestamp)
+      })
+    })
+
+    context("when the caller is not the owner", () => {
+      it("should revert", async () => {
+        await expect(
+          riskManagerV1
+            .connect(notifier)
+            .beginSignerBondsSwapStrategyUpdate(
+              anotherSignerBondsSwapStrategy.address
+            )
+        ).to.be.revertedWith("Ownable: caller is not the owner")
+      })
+    })
+  })
+
+  describe("finalizeSignerBondsSwapStrategyUpdate", () => {
+    context(
+      "when the change process is initialized, governance delay passed, " +
+        "and the caller is the owner",
+      () => {
+        let tx
+
+        beforeEach(async () => {
+          await riskManagerV1
+            .connect(owner)
+            .beginSignerBondsSwapStrategyUpdate(
+              anotherSignerBondsSwapStrategy.address
+            )
+
+          await increaseTime(43200) // +12h contract governance delay
+
+          tx = await riskManagerV1
+            .connect(owner)
+            .finalizeSignerBondsSwapStrategyUpdate()
+        })
+
+        it("should update the signer bonds swap strategy", async () => {
+          expect(await riskManagerV1.signerBondsSwapStrategy()).to.be.equal(
+            anotherSignerBondsSwapStrategy.address
+          )
+        })
+
+        it("should emit SignerBondsSwapStrategyUpdated event", async () => {
+          await expect(tx)
+            .to.emit(riskManagerV1, "SignerBondsSwapStrategyUpdated")
+            .withArgs(anotherSignerBondsSwapStrategy.address)
+        })
+
+        it("should reset the governance delay timer", async () => {
+          await expect(
+            riskManagerV1.getRemainingSignerBondsSwapStrategyChangeTime()
+          ).to.be.revertedWith("Update not initiated")
+        })
+
+        it("should reset new signer bonds swap strategy", async () => {
+          expect(await riskManagerV1.newSignerBondsSwapStrategy()).to.be.equal(
+            ZERO_ADDRESS
+          )
+        })
+      }
+    )
+
+    context("when the governance delay has not passed", () => {
+      it("should revert", async () => {
+        await riskManagerV1
+          .connect(owner)
+          .beginSignerBondsSwapStrategyUpdate(
+            anotherSignerBondsSwapStrategy.address
+          )
+
+        await increaseTime(39600) // +11h
+
+        await expect(
+          riskManagerV1.connect(owner).finalizeSignerBondsSwapStrategyUpdate()
+        ).to.be.revertedWith("Governance delay has not elapsed")
+      })
+    })
+
+    context("when the caller is not the owner", () => {
+      it("should revert", async () => {
+        await expect(
+          riskManagerV1
+            .connect(notifier)
+            .finalizeSignerBondsSwapStrategyUpdate()
+        ).to.be.revertedWith("Ownable: caller is not the owner")
+      })
+    })
+
+    context("when the update process is not initialized", () => {
+      it("should revert", async () => {
+        await expect(
+          riskManagerV1.connect(owner).finalizeSignerBondsSwapStrategyUpdate()
         ).to.be.revertedWith("Change not initiated")
       })
     })

--- a/test/RiskManagerV1.test.js
+++ b/test/RiskManagerV1.test.js
@@ -35,7 +35,6 @@ describe("RiskManagerV1", () => {
     signerBondsSwapStrategy = await SignerBondsSwapStrategy.deploy()
     await signerBondsSwapStrategy.deployed()
 
-    // TODO: Another type of strategy could be used
     anotherSignerBondsSwapStrategy = await SignerBondsSwapStrategy.deploy()
     await anotherSignerBondsSwapStrategy.deployed()
 
@@ -408,7 +407,7 @@ describe("RiskManagerV1", () => {
           )
       })
 
-      it("should not update the signerBondsSwapStrategy", async () => {
+      it("should not update the signer bonds swap strategy", async () => {
         expect(await riskManagerV1.signerBondsSwapStrategy()).to.be.equal(
           signerBondsSwapStrategy.address
         )
@@ -438,6 +437,16 @@ describe("RiskManagerV1", () => {
               anotherSignerBondsSwapStrategy.address
             )
         ).to.be.revertedWith("Ownable: caller is not the owner")
+      })
+    })
+
+    context("when signer bonds swap strategy is invalid", () => {
+      it("should revert", async () => {
+        await expect(
+          riskManagerV1
+            .connect(owner)
+            .beginSignerBondsSwapStrategyUpdate(ZERO_ADDRESS)
+        ).to.be.revertedWith("Invalid signer bonds swap strategy address")
       })
     })
   })


### PR DESCRIPTION
This pull request adds logic for updating signer bonds swap strategy in `RiskManagerV1`.

There are two functions added:
- `beginSignerBondsSwapStrategyUpdate`
- `finalizeSignerBondsSwapStrategyUpdate`

The delay used is `GEVERNANCE_TIME_DELAY` with is 12h.