### PR TITLE
Drafting calculation of tbtc auction value in percent

### DIFF
--- a/contracts/test/DepositStub.sol
+++ b/contracts/test/DepositStub.sol
@@ -36,7 +36,7 @@ contract DepositStub is IDeposit {
     IERC20 public tbtcToken;
     uint256 public override lotSizeTbtc;
     uint256 public override currentState;
-    uint256 public override collateralizationPercentage = 101;
+    uint256 public override auctionValue;
 
     address public buyer;
 


### PR DESCRIPTION
WIP.. this PR is addressing the following comment: https://github.com/keep-network/coverage-pools/pull/53#issuecomment-849686389

More prod. code and tests will be added after we agree on the general [approach](e258a25).

We need to calculate the percentage value of tbtc auction in liquidation with signer bonds in exchange for TBTC. Signer bonds are seized for the deposits in liquidation and we cannot use `deposit.collateralizationPercentage()` because it will return `0`. The idea in this PR is to use `deposit.auctionValue()` instead and read the current market ETH/BTC ratio. Based on the current collateral percentage value we can decide if a coverage pool auction should be opened or not.