### PR TITLE
Update one less mapping when opening an auction

### DIFF
--- a/contracts/Auctioneer.sol
+++ b/contracts/Auctioneer.sol
@@ -29,7 +29,11 @@ contract Auctioneer is CloneFactory {
     // Holds the address of the auction contract
     // which will be used as a master contract for cloning.
     address public masterAuction;
-    mapping(address => bool) public openAuctions;
+
+    // Maps auction to the item being on offer for that auction (e.g. a tBTC
+    // deposit). Must be filled by the risk manager after `createAuction` was
+    // called.
+    mapping(address => address) public openAuctions;
 
     CoveragePool public coveragePool;
 
@@ -72,7 +76,10 @@ contract Auctioneer is CloneFactory {
         uint256 tokenAmountPaid,
         uint256 portionToSeize
     ) external {
-        require(openAuctions[msg.sender], "Sender isn't an auction");
+        require(
+            openAuctions[msg.sender] != address(0),
+            "Sender isn't an auction"
+        );
 
         emit AuctionOfferTaken(
             msg.sender,
@@ -126,8 +133,6 @@ contract Auctioneer is CloneFactory {
             auctionLength
         );
 
-        openAuctions[cloneAddress] = true;
-
         emit AuctionCreated(
             address(tokenAccepted),
             amountDesired,
@@ -147,7 +152,10 @@ contract Auctioneer is CloneFactory {
     function earlyCloseAuction(Auction auction) internal returns (uint256) {
         address auctionAddress = address(auction);
 
-        require(openAuctions[auctionAddress], "Address is not an open auction");
+        require(
+            openAuctions[auctionAddress] != address(0),
+            "Address is not an open auction"
+        );
 
         uint256 amountTransferred = auction.amountTransferred();
 

--- a/contracts/test/AuctioneerStub.sol
+++ b/contracts/test/AuctioneerStub.sol
@@ -27,4 +27,11 @@ contract AuctioneerStub is Auctioneer {
         uint256 transferredAmount = earlyCloseAuction(auction);
         emit AuctionEarlyClosed(transferredAmount);
     }
+
+    /// @dev Needed to set the item that will be on offer (e.g. tBTC deposit).
+    ///      Used for test purposes. In real flow the item on offer is set by
+    ///      the risk manager.
+    function setAuctionItem(address auction, address auctionItem) public {
+        openAuctions[auction] = auctionItem;
+    }
 }

--- a/test/Auction.test.js
+++ b/test/Auction.test.js
@@ -235,8 +235,8 @@ describe("Auction", () => {
           )
 
           expect(
-            (actualPortionOnOffer * totalValueLocked) / divisor
-          ).to.be.closeTo(minLotSize * BTCETHPrice, precision)
+            actualPortionOnOffer.mul(totalValueLocked).div(divisor)
+          ).to.be.closeTo(minLotSize.mul(BTCETHPrice), to1ePrecision(3, 13))
         }
       )
     })
@@ -718,6 +718,12 @@ describe("Auction", () => {
     const events = pastEvents(receipt, auctioneer, "AuctionCreated")
     const auctionAddress = events[0].args["auctionAddress"]
 
+    // Simulate setting the address of the auction item (e.g. tBTC deposit) by
+    // the risk manager
+    await auctioneer.setAuctionItem(
+      auctionAddress,
+      "0x0000000000000000000000000000000000000001"
+    )
     return new ethers.Contract(auctionAddress, AuctionJSON.abi, owner)
   }
 

--- a/test/RiskManagerV1.test.js
+++ b/test/RiskManagerV1.test.js
@@ -158,6 +158,12 @@ describe("RiskManagerV1", () => {
               expect(auctionAddress).to.not.equal(ZERO_ADDRESS)
             })
 
+            it("should map the auction to deposit", async () => {
+              expect(
+                await riskManagerV1.openAuctions(auctionAddress)
+              ).to.be.equal(mockIDeposit.address)
+            })
+
             it("should not use the surplus pool", async () => {
               expect(await riskManagerV1.tbtcSurplus()).to.be.equal(
                 to1ePrecision(30, 16)
@@ -336,7 +342,9 @@ describe("RiskManagerV1", () => {
         expect(await riskManagerV1.depositToAuction(auctionAddress)).to.equal(
           ZERO_ADDRESS
         )
-        expect(await riskManagerV1.openAuctions(auctionAddress)).to.be.false
+        expect(await riskManagerV1.openAuctions(auctionAddress)).to.be.equal(
+          ZERO_ADDRESS
+        )
       })
     })
   })


### PR DESCRIPTION
Work in progress

This pull request aims to limit the amount of storage taken in the `RiskManagerV1` contract for `auction`/`deposit` mappings by removing  `auctionToDeposit`.

It seems to decrease the gas usage:
- `notifyLiquidation`         317220 => 294963
- `notifyLiquidated`          62345  =>  59779
- `publicCreateAuction`   252425 => 230146
- `takeOffer`                      92689  =>  92780 