### PR TITLE
Deposit validation

### DIFF
--- a/contracts/RiskManagerV1.sol
+++ b/contracts/RiskManagerV1.sol
@@ -24,9 +24,9 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 
 /// @notice tBTC v1 Deposit contract interface.
 /// @dev This is an interface with just a few function signatures of a main
-///         contract for tBTC. For more info and function description
-///         please see:
-///         https://github.com/keep-network/tbtc/blob/solidity/v1.1.0/solidity/contracts/deposit/Deposit.sol
+///      contract for tBTC. For more info and function description
+///      please see:
+///      https://github.com/keep-network/tbtc/blob/solidity/v1.1.0/solidity/contracts/deposit/Deposit.sol
 interface IDeposit {
     function withdrawFunds() external;
 
@@ -41,6 +41,15 @@ interface IDeposit {
     function collateralizationPercentage() external view returns (uint256);
 
     function withdrawableAmount() external view returns (uint256);
+}
+
+/// @notice tBTC v1 deposit token interface.
+/// @dev This is an interface with just a few function signatures of a main
+///      contract for tBTC. For more info and function description
+///      please see:
+///      https://github.com/keep-network/tbtc/blob/solidity/v1.1.0/solidity/contracts/system/TBTCDepositToken.sol
+interface ITBTCDepositToken {
+    function exists(uint256 _tokenId) external view returns (bool);
 }
 
 /// @title ISignerBondsSwapStrategy
@@ -77,6 +86,7 @@ contract RiskManagerV1 is Auctioneer, Ownable {
     uint256 public auctionLengthChangeInitiated;
 
     IERC20 public tbtcToken;
+    ITBTCDepositToken public tbtcDepositToken;
     // tBTC surplus collected from early closed auctions.
     uint256 public tbtcSurplus;
 
@@ -125,6 +135,7 @@ contract RiskManagerV1 is Auctioneer, Ownable {
 
     constructor(
         IERC20 _tbtcToken,
+        ITBTCDepositToken _tbtcDepositToken,
         CoveragePool _coveragePool,
         ISignerBondsSwapStrategy _signerBondsSwapStrategy,
         address _masterAuction,
@@ -132,6 +143,7 @@ contract RiskManagerV1 is Auctioneer, Ownable {
         uint256 _collateralizationThreshold
     ) Auctioneer(_coveragePool, _masterAuction) {
         tbtcToken = _tbtcToken;
+        tbtcDepositToken = _tbtcDepositToken;
         signerBondsSwapStrategy = _signerBondsSwapStrategy;
         auctionLength = _auctionLength;
         collateralizationThreshold = _collateralizationThreshold;
@@ -145,6 +157,11 @@ contract RiskManagerV1 is Auctioneer, Ownable {
     /// @notice Creates an auction for tbtc deposit in liquidation state.
     /// @param  depositAddress tBTC Deposit address
     function notifyLiquidation(address depositAddress) external {
+        require(
+            tbtcDepositToken.exists(uint256(depositAddress)),
+            "Address is not a deposit contract"
+        );
+
         IDeposit deposit = IDeposit(depositAddress);
         require(
             deposit.currentState() == DEPOSIT_LIQUIDATION_IN_PROGRESS_STATE,

--- a/contracts/RiskManagerV1.sol
+++ b/contracts/RiskManagerV1.sol
@@ -195,6 +195,11 @@ contract RiskManagerV1 is Auctioneer, Ownable {
     /// @notice Closes an auction early.
     /// @param  depositAddress tBTC Deposit address
     function notifyLiquidated(address depositAddress) external {
+        require(
+            depositToAuction[depositAddress] != address(0),
+            "No auction for given deposit"
+        );
+
         IDeposit deposit = IDeposit(depositAddress);
         require(
             deposit.currentState() == DEPOSIT_LIQUIDATED_STATE,

--- a/contracts/RiskManagerV1.sol
+++ b/contracts/RiskManagerV1.sol
@@ -24,7 +24,7 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 
 /// @notice tBTC v1 Deposit contract interface.
 /// @dev This is an interface with just a few function signatures of a main
-///      contract for tBTC. For more info and function description
+///      contract from tBTC. For more info and function description
 ///      please see:
 ///      https://github.com/keep-network/tbtc/blob/solidity/v1.1.0/solidity/contracts/deposit/Deposit.sol
 interface IDeposit {
@@ -45,7 +45,7 @@ interface IDeposit {
 
 /// @notice tBTC v1 deposit token interface.
 /// @dev This is an interface with just a few function signatures of a main
-///      contract for tBTC. For more info and function description
+///      contract from tBTC. For more info and function description
 ///      please see:
 ///      https://github.com/keep-network/tbtc/blob/solidity/v1.1.0/solidity/contracts/system/TBTCDepositToken.sol
 interface ITBTCDepositToken {

--- a/contracts/test/RiskManagerV1Stub.sol
+++ b/contracts/test/RiskManagerV1Stub.sol
@@ -10,6 +10,7 @@ contract RiskManagerV1Stub is RiskManagerV1 {
 
     constructor(
         IERC20 _tbtcToken,
+        ITBTCDepositToken _tbtcDepositToken,
         CoveragePool _coveragePool,
         ISignerBondsSwapStrategy _signerBondsSwapStrategy,
         address _masterAuction,
@@ -18,6 +19,7 @@ contract RiskManagerV1Stub is RiskManagerV1 {
     )
         RiskManagerV1(
             _tbtcToken,
+            _tbtcDepositToken,
             _coveragePool,
             _signerBondsSwapStrategy,
             _masterAuction,

--- a/test/RiskManagerV1.test.js
+++ b/test/RiskManagerV1.test.js
@@ -303,9 +303,19 @@ describe("RiskManagerV1", () => {
   })
 
   describe("notifyLiquidated", () => {
+    context("when auction for deposit does not exist", () => {
+      it("should revert", async () => {
+        const otherDeposit = await deployMockContract(owner, IDeposit.abi)
+
+        await expect(
+          riskManagerV1.notifyLiquidated(otherDeposit.address)
+        ).to.be.revertedWith("No auction for given deposit")
+      })
+    })
+
     context("when deposit is not in liquidated state", () => {
       it("should revert", async () => {
-        await mockIDeposit.mock.currentState.returns(4) // Active state
+        await notifyLiquidation()
 
         await expect(
           riskManagerV1.notifyLiquidated(mockIDeposit.address)

--- a/test/RiskManagerV1.test.js
+++ b/test/RiskManagerV1.test.js
@@ -89,12 +89,9 @@ describe("RiskManagerV1", () => {
     })
 
     context("when address is a deposit contract", () => {
-      beforeEach(async () => {
-        await mockTbtcDepositToken.mock.exists.returns(true)
-      })
-
       context("when deposit is not in liquidation state", () => {
         it("should revert", async () => {
+          await mockTbtcDepositToken.mock.exists.returns(true)
           await mockIDeposit.mock.currentState.returns(4) // Active state
 
           await expect(
@@ -108,6 +105,7 @@ describe("RiskManagerV1", () => {
           "when deposit is above collateralization threshold level",
           () => {
             it("should revert", async () => {
+              await mockTbtcDepositToken.mock.exists.returns(true)
               await mockIDeposit.mock.currentState.returns(
                 depositLiquidationInProgressState
               )
@@ -742,6 +740,7 @@ describe("RiskManagerV1", () => {
   })
 
   async function notifyLiquidation() {
+    await mockTbtcDepositToken.mock.exists.returns(true)
     await mockIDeposit.mock.currentState.returns(
       depositLiquidationInProgressState
     )

--- a/test/integration/liquidation.test.js
+++ b/test/integration/liquidation.test.js
@@ -2,7 +2,7 @@ const { expect } = require("chai")
 const { to1e18 } = require("../helpers/contract-test-helpers")
 const Auction = require("../../artifacts/contracts/Auction.sol/Auction.json")
 
-describe("Integration", () => {
+describe("Integration -- liquidation", () => {
   const auctionLength = 86400 // 24h
   const lotSize = to1e18(10)
   const bondedAmount = to1e18(150)

--- a/test/integration/liquidation.test.js
+++ b/test/integration/liquidation.test.js
@@ -1,6 +1,8 @@
 const { expect } = require("chai")
 const { to1e18 } = require("../helpers/contract-test-helpers")
+const { deployMockContract } = require("@ethereum-waffle/mock-contract")
 const Auction = require("../../artifacts/contracts/Auction.sol/Auction.json")
+const ITBTCDepositToken = require("../../artifacts/contracts/RiskManagerV1.sol/ITBTCDepositToken.json")
 
 describe("Integration -- liquidation", () => {
   const auctionLength = 86400 // 24h
@@ -14,13 +16,26 @@ describe("Integration -- liquidation", () => {
   let riskManagerV1
   let tbtcDeposit
 
+  let owner
   let bidder
   let thirdParty
 
   beforeEach(async () => {
+    owner = await ethers.getSigner(0)
+    bidder = await ethers.getSigner(1)
+    thirdParty = await ethers.getSigner(2)
+
     const TestToken = await ethers.getContractFactory("TestToken")
     tbtcToken = await TestToken.deploy()
     await tbtcToken.deployed()
+
+    // For brevity, use a mock tBTC deposit token contract and simulate
+    // all deposits are legit.
+    const mockTbtcDepositToken = await deployMockContract(
+      owner,
+      ITBTCDepositToken.abi
+    )
+    await mockTbtcDepositToken.mock.exists.returns(true)
 
     const SignerBondsSwapStrategy = await ethers.getContractFactory(
       "SignerBondsEscrow"
@@ -40,6 +55,7 @@ describe("Integration -- liquidation", () => {
     const RiskManagerV1 = await ethers.getContractFactory("RiskManagerV1")
     riskManagerV1 = await RiskManagerV1.deploy(
       tbtcToken.address,
+      mockTbtcDepositToken.address,
       coveragePool.address,
       signerBondsSwapStrategy.address,
       masterAuction.address,
@@ -52,15 +68,10 @@ describe("Integration -- liquidation", () => {
     tbtcDeposit = await DepositStub.deploy(tbtcToken.address, lotSize)
     await tbtcDeposit.deployed()
 
-    await ethers.getSigner(0).then((s) =>
-      s.sendTransaction({
-        to: tbtcDeposit.address,
-        value: bondedAmount,
-      })
-    )
-
-    bidder = await ethers.getSigner(1)
-    thirdParty = await ethers.getSigner(2)
+    await owner.sendTransaction({
+      to: tbtcDeposit.address,
+      value: bondedAmount,
+    })
 
     await tbtcToken.mint(bidder.address, lotSize)
     await tbtcToken.mint(thirdParty.address, lotSize)

--- a/test/system/deposit-validation.test.js
+++ b/test/system/deposit-validation.test.js
@@ -1,0 +1,134 @@
+const { expect } = require("chai")
+const {
+  to1e18,
+  impersonateAccount,
+  resetFork,
+  increaseTime,
+  ZERO_ADDRESS,
+} = require("../helpers/contract-test-helpers")
+
+const describeFn =
+  process.env.NODE_ENV === "system-test" ? describe : describe.skip
+
+// This system test scenario checks the deposit validation mechanism.
+// It is meant to be executed on Hardhat Network with mainnet forking enabled.
+// At the start, the fork is being reset to the specific starting block which
+// determines the initial test state. This test uses real mainnet contracts.
+// The case presented here simulates that a third party deploys an arbitrary,
+// possibly malicious deposit contract. Then, it tries to open an auction
+// for that deposit to perform potentially harmful actions on the coverage pool.
+// However, deposit validation mechanism should prevent to open an auction
+// due to lack of the tBTC deposit token for the fake deposit. In general,
+// the risk manager should open an auction only when being notified about
+// liquidation of a real deposit, represented by an existing tBTC deposit token.
+describeFn("System -- deposit validation", () => {
+  const startingBlock = 12368838
+  const tbtcTokenAddress = "0x8daebade922df735c38c80c7ebd708af50815faa"
+  const thirdPartyAddress = "0xa0216ED2202459068a750bDf74063f677613DA34"
+  const keepTokenAddress = "0x85Eee30c52B0b379b046Fb0F85F4f3Dc3009aFEC"
+  const tbtcDepositTokenAddress = "0x10b66bd1e3b5a936b7f8dbc5976004311037cdf0"
+  const auctionLength = 86400 // 24h
+  const collateralizationThreshold = 300
+
+  let tbtcToken
+  let underwriterToken
+  let assetPool
+  let signerBondsSwapStrategy
+  let coveragePool
+  let riskManagerV1
+  let fakeDeposit
+
+  let governance
+  let rewardsManager
+  let thirdParty
+
+  before(async () => {
+    await resetFork(startingBlock)
+
+    governance = await ethers.getSigner(0)
+    rewardsManager = await ethers.getSigner(1)
+    thirdParty = await impersonateAccount(thirdPartyAddress)
+
+    tbtcToken = await ethers.getContractAt("IERC20", tbtcTokenAddress)
+
+    const UnderwriterToken = await ethers.getContractFactory("UnderwriterToken")
+    underwriterToken = await UnderwriterToken.deploy("Coverage KEEP", "covKEEP")
+    await underwriterToken.deployed()
+
+    const AssetPool = await ethers.getContractFactory("AssetPool")
+    assetPool = await AssetPool.deploy(
+      keepTokenAddress,
+      underwriterToken.address,
+      rewardsManager.address
+    )
+    await assetPool.deployed()
+    await underwriterToken.transferOwnership(assetPool.address)
+
+    const SignerBondsSwapStrategy = await ethers.getContractFactory(
+      "SignerBondsEscrow"
+    )
+    signerBondsSwapStrategy = await SignerBondsSwapStrategy.deploy()
+    await signerBondsSwapStrategy.deployed()
+
+    const Auction = await ethers.getContractFactory("Auction")
+
+    const masterAuction = await Auction.deploy()
+    await masterAuction.deployed()
+
+    const CoveragePool = await ethers.getContractFactory("CoveragePool")
+    coveragePool = await CoveragePool.deploy(assetPool.address)
+    await coveragePool.deployed()
+    await assetPool.transferOwnership(coveragePool.address)
+
+    const RiskManagerV1 = await ethers.getContractFactory("RiskManagerV1")
+    riskManagerV1 = await RiskManagerV1.deploy(
+      tbtcToken.address,
+      tbtcDepositTokenAddress,
+      coveragePool.address,
+      signerBondsSwapStrategy.address,
+      masterAuction.address,
+      auctionLength,
+      collateralizationThreshold
+    )
+    await riskManagerV1.deployed()
+
+    await coveragePool
+      .connect(governance)
+      .beginRiskManagerApproval(riskManagerV1.address)
+    await increaseTime(2592000) // +30 days
+    await coveragePool
+      .connect(governance)
+      .finalizeRiskManagerApproval(riskManagerV1.address)
+
+    // Suppose a third party deploys an arbitrary deposit contract.
+    // For simplicity, let's say it's just the DepositStub.
+    const DepositStub = await ethers.getContractFactory("DepositStub")
+    fakeDeposit = await DepositStub.connect(thirdParty).deploy(
+      tbtcToken.address,
+      to1e18(1)
+    )
+    await fakeDeposit.deployed()
+  })
+
+  describe("initial state", () => {
+    it("should assert the fake deposit's auction does not exist", async () => {
+      const auctionAddress = await riskManagerV1.depositToAuction(
+        fakeDeposit.address
+      )
+      expect(auctionAddress).to.be.equal(ZERO_ADDRESS)
+    })
+  })
+
+  describe("when trying to open an auction for a fake deposit", () => {
+    it("should revert the notify liquidation transaction", async () => {
+      // The third party tries to open an auction for the fake deposit.
+      await expect(
+        riskManagerV1.connect(thirdParty).notifyLiquidation(fakeDeposit.address)
+      ).to.be.revertedWith("Address is not a deposit contract")
+
+      expect(
+        await riskManagerV1.depositToAuction(fakeDeposit.address)
+      ).to.be.equal(ZERO_ADDRESS)
+    })
+  })
+})

--- a/test/system/deposit-validation.test.js
+++ b/test/system/deposit-validation.test.js
@@ -110,12 +110,14 @@ describeFn("System -- deposit validation", () => {
     await fakeDeposit.deployed()
   })
 
-  describe("initial state", () => {
-    it("should assert the fake deposit's auction does not exist", async () => {
-      const auctionAddress = await riskManagerV1.depositToAuction(
-        fakeDeposit.address
-      )
-      expect(auctionAddress).to.be.equal(ZERO_ADDRESS)
+  describe("test initial state", () => {
+    describe("fake deposit's auction", () => {
+      it("should not exist", async () => {
+        const auctionAddress = await riskManagerV1.depositToAuction(
+          fakeDeposit.address
+        )
+        expect(auctionAddress).to.be.equal(ZERO_ADDRESS)
+      })
     })
   })
 

--- a/test/system/liquidation.test.js
+++ b/test/system/liquidation.test.js
@@ -28,6 +28,7 @@ describeFn("System -- liquidation", () => {
   const depositAddress = "0x55d8b1dd88e60d12c81b5479186c15d07555db9d"
   const bidderAddress = "0xa0216ED2202459068a750bDf74063f677613DA34"
   const keepTokenAddress = "0x85Eee30c52B0b379b046Fb0F85F4f3Dc3009aFEC"
+  const tbtcDepositTokenAddress = "0x10b66bd1e3b5a936b7f8dbc5976004311037cdf0"
   const auctionLength = 86400 // 24h
   const collateralizationThreshold = 300
   // deposit lot size is 5 BTC
@@ -89,6 +90,7 @@ describeFn("System -- liquidation", () => {
     const RiskManagerV1 = await ethers.getContractFactory("RiskManagerV1")
     riskManagerV1 = await RiskManagerV1.deploy(
       tbtcToken.address,
+      tbtcDepositTokenAddress,
       coveragePool.address,
       signerBondsSwapStrategy.address,
       masterAuction.address,

--- a/test/system/liquidation.test.js
+++ b/test/system/liquidation.test.js
@@ -22,7 +22,7 @@ const describeFn =
 // end of the scenario, the risk manager should liquidate the deposit successfully,
 // and 66% of the deposit's bonded amount should land on the signer bonds
 // swap strategy contract.
-describeFn("System -- liquidation happy path", () => {
+describeFn("System -- liquidation", () => {
   const startingBlock = 12368838
   const tbtcTokenAddress = "0x8daebade922df735c38c80c7ebd708af50815faa"
   const depositAddress = "0x55d8b1dd88e60d12c81b5479186c15d07555db9d"

--- a/test/system/liquidation.test.js
+++ b/test/system/liquidation.test.js
@@ -112,16 +112,20 @@ describeFn("System -- liquidation", () => {
     bidder = await impersonateAccount(bidderAddress)
   })
 
-  describe("initial state", () => {
-    it("should assert a deposit is in active state", async () => {
-      expect(await tbtcDeposit.currentState()).to.equal(5) // Active
+  describe("test initial state", () => {
+    describe("deposit", () => {
+      it("should be in active state", async () => {
+        expect(await tbtcDeposit.currentState()).to.equal(5) // Active
+      })
     })
 
-    it("should assert an auction does not exist", async () => {
-      const auctionAddress = await riskManagerV1.depositToAuction(
-        tbtcDeposit.address
-      )
-      expect(auctionAddress).to.be.equal(ZERO_ADDRESS)
+    describe("auction", () => {
+      it("should not exist", async () => {
+        const auctionAddress = await riskManagerV1.depositToAuction(
+          tbtcDeposit.address
+        )
+        expect(auctionAddress).to.be.equal(ZERO_ADDRESS)
+      })
     })
   })
 


### PR DESCRIPTION
Closes #70 
Closes #72 

The risk manager should open auctions only when being notified about the liquidation of real deposits, represented by existing tBTC deposit tokens.

This change list includes appropriate unit and system test scenarios that prove the mechanism works well and simulates a case when it blocks an illegal attempt of opening an auction for a fake deposit.

By the way, the structure of integration and system test has been adjusted. Each scenario is now placed in separate file. Single files with multiple scenarios will probably become unreadable in the future.