### PR TITLE
Allow only collateral token to call receiveApproval

### DIFF
--- a/contracts/AssetPool.sol
+++ b/contracts/AssetPool.sol
@@ -100,8 +100,9 @@ contract AssetPool is Ownable {
         address token,
         bytes calldata
     ) external {
+        require(msg.sender == token, "Only token caller allowed");
         require(
-            IERC20(token) == collateralToken,
+            token == address(collateralToken),
             "Unsupported collateral token"
         );
 

--- a/contracts/test/TestToken.sol
+++ b/contracts/test/TestToken.sol
@@ -4,6 +4,16 @@ pragma solidity <0.9.0;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
+// See https://github.com/keep-network/keep-core/blob/v1.0.1/solidity/contracts/KeepToken.sol
+interface tokenRecipient {
+    function receiveApproval(
+        address _from,
+        uint256 _value,
+        address _token,
+        bytes calldata _extraData
+    ) external;
+}
+
 contract TestToken is ERC20 {
     string public constant NAME = "Test Token";
     string public constant SYMBOL = "TT";
@@ -13,9 +23,25 @@ contract TestToken is ERC20 {
 
     /// @dev             Mints an amount of the token and assigns it to an account.
     ///                  Uses the internal _mint function. Anyone can call
-    /// @param _account  The account that will receive the created tokens.
-    /// @param _amount   The amount of tokens that will be created.
-    function mint(address _account, uint256 _amount) public {
-        _mint(_account, _amount);
+    /// @param account  The account that will receive the created tokens.
+    /// @param amount   The amount of tokens that will be created.
+    function mint(address account, uint256 amount) public {
+        _mint(account, amount);
+    }
+
+    function approveAndCall(
+        address spender,
+        uint256 value,
+        bytes memory extraData
+    ) public returns (bool success) {
+        if (approve(spender, value)) {
+            tokenRecipient(spender).receiveApproval(
+                msg.sender,
+                value,
+                address(this),
+                extraData
+            );
+            return true;
+        }
     }
 }

--- a/test/AssetPool.test.js
+++ b/test/AssetPool.test.js
@@ -225,6 +225,67 @@ describe("AssetPool", () => {
     })
   })
 
+  describe("receiveApproval", () => {
+    context("when called directly", () => {
+      it("should revert", async () => {
+        await expect(
+          assetPool
+            .connect(underwriter1)
+            .receiveApproval(
+              underwriter1.address,
+              to1e18(100),
+              collateralToken.address,
+              []
+            )
+        ).to.be.revertedWith("Only token caller allowed")
+      })
+    })
+
+    context("when called for unsupported token", () => {
+      const amount = to1e18(100)
+      let unsupportedToken
+
+      beforeEach(async () => {
+        const TestToken = await ethers.getContractFactory("TestToken")
+        unsupportedToken = await TestToken.deploy()
+        await unsupportedToken.deployed()
+      })
+
+      it("should revert", async () => {
+        await expect(
+          unsupportedToken
+            .connect(underwriter1)
+            .approveAndCall(assetPool.address, amount, [])
+        ).to.be.revertedWith("Unsupported collateral token")
+      })
+    })
+
+    context("when called via approveAndCall", () => {
+      const amount = to1e18(100)
+
+      beforeEach(async () => {
+        await collateralToken
+          .connect(underwriter1)
+          .approveAndCall(assetPool.address, amount, [])
+      })
+
+      it("should mint underwriter tokens to the caller", async () => {
+        expect(await underwriterToken.balanceOf(underwriter1.address)).to.equal(
+          amount
+        )
+      })
+
+      it("should transfer deposited amount to the pool", async () => {
+        expect(await collateralToken.balanceOf(assetPool.address)).to.equal(
+          amount
+        )
+        expect(
+          await collateralToken.balanceOf(underwriter1.address)
+        ).to.be.equal(underwriterInitialCollateralBalance.sub(amount))
+      })
+    })
+  })
+
   describe("claim", () => {
     beforeEach(async () => {
       await assetPool.connect(underwriter1).deposit(to1e18(200))


### PR DESCRIPTION
Refs #59 
Closes #69 

Only collateral token can call `receiveApproval `function.

`receiveApproval` is needed for `approveAndCall` so that underwriters can
deposit tokens in one transaction. Not every token supports
`approveAndCall` but KEEP token does, so being able to deposit via
`approveAndCall` is handy, especially for v1 of coverage pools where
KEEP will be the only asset supported.

Without requiring that only collateral token can call `receiveApproval`,
we are leaving a possibility for third parties to invest on behalf of
underwriters who approved the asset pool. This is especially interesting
in scenarios when the collateral token does not reduce approval in
case the caller is the spender.

From [UNI token](https://etherscan.io/address/0x1f9840a85d5af5bf1d1762f925bdaddc4201f984#code) contract code:
```
function transferFrom(
  address src,
  address dst,
  uint rawAmount
) external returns (bool) {
  address spender = msg.sender;
   // (...)

  if (spender != src && spenderAllowance != uint96(-1)) {
    // update allowance
  }

  _transferTokens(src, dst, amount);
  return true;
}
```

What could happen:
- Bob has 1,000,000 UNI.
- Bob calls `uniToken.approve` for 100 UNI.
- Bob calls `assetPool.receiveApproval` for 100 UNI. Bob receives 100 COV.
- Bob calls `assetPool.initiateWithdrawal`, 100 COV is transferred to Asset Pool.
- Eve calls `assetPool.receiveApproval` for 100 UNI of Bob's. This is possible
because UNI token did not lower the approval for Bob's `assetPool.receiveApproval`
call in the third step. Bob receives 100 COV.