### PR TITLE
 Validate deposit's bond auction value

### DIFF
--- a/contracts/RiskManagerV1.sol
+++ b/contracts/RiskManagerV1.sol
@@ -151,7 +151,11 @@ contract RiskManagerV1 is Auctioneer, Ownable {
             "Deposit is not in liquidation state"
         );
 
-        // TODO: check bondAuctionThreshold
+        require(
+            deposit.auctionValue() >=
+                address(deposit).balance.mul(bondAuctionThreshold).div(100),
+            "Deposit bond auction percentage is below the threshold level"
+        );
 
         // TODO: need to add some % to "lotSizeTbtc" to cover a notifier incentive.
         uint256 lotSizeTbtc = deposit.lotSizeTbtc();

--- a/contracts/test/DepositStub.sol
+++ b/contracts/test/DepositStub.sol
@@ -79,6 +79,10 @@ contract DepositStub is IDeposit {
         return address(this).balance;
     }
 
+    //
+    // Not in tBTC deposit interface, functions below were added just for tests.
+    //
+
     function setAuctionValue(uint256 _auctionValue) external {
         auctionValue = _auctionValue;
     }

--- a/contracts/test/DepositStub.sol
+++ b/contracts/test/DepositStub.sol
@@ -36,7 +36,6 @@ contract DepositStub is IDeposit {
     IERC20 public tbtcToken;
     uint256 public override lotSizeTbtc;
     uint256 public override currentState;
-    uint256 public override collateralizationPercentage = 101;
 
     address public buyer;
 

--- a/contracts/test/DepositStub.sol
+++ b/contracts/test/DepositStub.sol
@@ -36,12 +36,14 @@ contract DepositStub is IDeposit {
     IERC20 public tbtcToken;
     uint256 public override lotSizeTbtc;
     uint256 public override currentState;
+    uint256 public override auctionValue;
 
     address public buyer;
 
     constructor(IERC20 _tbtcToken, uint256 _lotSizeTbtc) {
         tbtcToken = _tbtcToken;
         lotSizeTbtc = _lotSizeTbtc;
+        currentState = 4; // active by default
     }
 
     /// @dev Needed to receive ETH bonds at deposit setup.
@@ -75,5 +77,9 @@ contract DepositStub is IDeposit {
 
     function withdrawableAmount() external view override returns (uint256) {
         return address(this).balance;
+    }
+
+    function setAuctionValue(uint256 _auctionValue) external {
+        auctionValue = _auctionValue;
     }
 }

--- a/contracts/test/RiskManagerV1Stub.sol
+++ b/contracts/test/RiskManagerV1Stub.sol
@@ -14,7 +14,7 @@ contract RiskManagerV1Stub is RiskManagerV1 {
         ISignerBondsSwapStrategy _signerBondsSwapStrategy,
         address _masterAuction,
         uint256 _auctionLength,
-        uint256 _collateralizationThreshold
+        uint256 _bondAuctionThreshold
     )
         RiskManagerV1(
             _tbtcToken,
@@ -22,7 +22,7 @@ contract RiskManagerV1Stub is RiskManagerV1 {
             _signerBondsSwapStrategy,
             _masterAuction,
             _auctionLength,
-            _collateralizationThreshold
+            _bondAuctionThreshold
         )
     {}
 

--- a/docs/design.adoc
+++ b/docs/design.adoc
@@ -235,9 +235,9 @@ collateral ratios and scaling tBTC’s TVL. The coverage pool serves as a buyer
 of last resort. It purchases enough TBTC on auction to make the depositor whole
 in the event of liquidation if the stakers' collateral is not sufficient.
 
-In case of liquidation of a tBTC deposit below a certain collateralization
+In case of liquidation of a tBTC deposit at or above a certain bond auction
 threshold, the risk manager opens an auction to acquire TBTC to purchase signer
-bonds. Collateralization threshold and auction length are governable parameters. 
+bonds. Bond auction threshold and auction length are governable parameters.
 
 ETH purchased by the risk manager from tBTC signer bonds is swapped and
 transferred to the asset pool and there are two strategies for doing that:
@@ -290,9 +290,9 @@ The governance included in the system design follows two principles:
 |Governance can adjust auction length based on coverage pool TVL and the minimum 
 possible auctioned value.
 
-|tBTC deposit collateralization
+|tBTC deposit bond auction threshold
 |12 hours
-|Governance can set the maximum collateralization level of tBTC deposit under
+|Governance can set the minimum bond auction level of tBTC deposit under
 the liquidation the tBTC v1 risk manager is going to open an auction for. The
 risk manager is a buyer of the last resort and should not work with tBTC
 liquidating deposits still attractive for arbitraging bots.

--- a/test/RiskManagerV1.test.js
+++ b/test/RiskManagerV1.test.js
@@ -298,7 +298,11 @@ describe("RiskManagerV1", () => {
   describe("notifyLiquidated", () => {
     context("when auction for deposit does not exist", () => {
       it("should revert", async () => {
-        const otherDeposit = await deployMockContract(owner, IDeposit.abi)
+        const DepositStub = await ethers.getContractFactory("DepositStub")
+        const otherDeposit = await DepositStub.deploy(
+          tbtcToken.address,
+          auctionLotSize
+        )
 
         await expect(
           riskManagerV1.notifyLiquidated(otherDeposit.address)

--- a/test/RiskManagerV1.test.js
+++ b/test/RiskManagerV1.test.js
@@ -338,9 +338,11 @@ describe("RiskManagerV1", () => {
         await auction.connect(bidder).takeOffer(to1ePrecision(25, 16))
 
         // Simulate that deposit was liquidated by someone else.
-        await tbtcToken.mint(owner.address, auctionLotSize)
-        await tbtcToken.approve(depositStub.address, auctionLotSize)
-        await depositStub.purchaseSignerBondsAtAuction()
+        await tbtcToken.connect(owner).mint(owner.address, auctionLotSize)
+        await tbtcToken
+          .connect(owner)
+          .approve(depositStub.address, auctionLotSize)
+        await depositStub.connect(owner).purchaseSignerBondsAtAuction()
       })
 
       it("should emit notified liquidated event", async () => {

--- a/test/integration/integration.test.js
+++ b/test/integration/integration.test.js
@@ -6,7 +6,7 @@ describe("Integration", () => {
   const auctionLength = 86400 // 24h
   const lotSize = to1e18(10)
   const bondedAmount = to1e18(150)
-  const collateralizationThreshold = 101
+  const bondAuctionThreshold = 100
 
   let tbtcToken
   let signerBondsSwapStrategy
@@ -44,7 +44,7 @@ describe("Integration", () => {
       signerBondsSwapStrategy.address,
       masterAuction.address,
       auctionLength,
-      collateralizationThreshold
+      bondAuctionThreshold
     )
     await riskManagerV1.deployed()
 

--- a/test/integration/integration.test.js
+++ b/test/integration/integration.test.js
@@ -51,6 +51,7 @@ describe("Integration", () => {
     const DepositStub = await ethers.getContractFactory("DepositStub")
     tbtcDeposit = await DepositStub.deploy(tbtcToken.address, lotSize)
     await tbtcDeposit.deployed()
+    await tbtcDeposit.setAuctionValue(bondedAmount)
 
     await ethers.getSigner(0).then((s) =>
       s.sendTransaction({

--- a/test/system/system.test.js
+++ b/test/system/system.test.js
@@ -29,7 +29,7 @@ describeFn("System -- liquidation happy path", () => {
   const bidderAddress = "0xa0216ED2202459068a750bDf74063f677613DA34"
   const keepTokenAddress = "0x85Eee30c52B0b379b046Fb0F85F4f3Dc3009aFEC"
   const auctionLength = 86400 // 24h
-  const collateralizationThreshold = 300
+  const bondAuctionThreshold = 66 // lets the deposit pass without waiting
   // deposit lot size is 5 BTC
   const lotSize = to1e18(5)
   // signers have bonded 290.81 ETH
@@ -93,7 +93,7 @@ describeFn("System -- liquidation happy path", () => {
       signerBondsSwapStrategy.address,
       masterAuction.address,
       auctionLength,
-      collateralizationThreshold
+      bondAuctionThreshold
     )
     await riskManagerV1.deployed()
 

--- a/test/system/system.test.js
+++ b/test/system/system.test.js
@@ -20,7 +20,7 @@ const describeFn =
 // which is ready to be liquidated at the starting block. The bidder which
 // takes the offer is also a real account with actual tBTC balance. At the
 // end of the scenario, the risk manager should liquidate the deposit successfully,
-// and 66% of the deposit's bonded amount should land on the signer bonds
+// and 75% of the deposit's bonded amount should land on the signer bonds
 // swap strategy contract.
 describeFn("System -- liquidation happy path", () => {
   const startingBlock = 12368838
@@ -29,13 +29,15 @@ describeFn("System -- liquidation happy path", () => {
   const bidderAddress = "0xa0216ED2202459068a750bDf74063f677613DA34"
   const keepTokenAddress = "0x85Eee30c52B0b379b046Fb0F85F4f3Dc3009aFEC"
   const auctionLength = 86400 // 24h
-  const bondAuctionThreshold = 66 // lets the deposit pass without waiting
+  // Only deposits with at least 75% of bonds offered on bond auction will be
+  // accepted by the risk manager.
+  const bondAuctionThreshold = 75
   // deposit lot size is 5 BTC
   const lotSize = to1e18(5)
   // signers have bonded 290.81 ETH
   const bondedAmount = BigNumber.from("290810391624000000000")
-  // 66% of the deposit is exposed on auction in the liquidation moment
-  const bondedAmountPercentage = BigNumber.from("66")
+  // 75% of the deposit is exposed on auction in the liquidation moment
+  const bondedAmountPercentage = BigNumber.from("75")
 
   let tbtcToken
   let underwriterToken
@@ -130,6 +132,22 @@ describeFn("System -- liquidation happy path", () => {
 
     before(async () => {
       await tbtcDeposit.notifyRedemptionSignatureTimedOut()
+
+      // The deposit's auction must offer at least 75% of bonds to be accepted
+      // by the risk manager. At starting block, the deposit's auction exposes
+      // 66% so an immediate `notifyLiquidation` must revert.
+      await expect(
+        riskManagerV1.notifyLiquidation(tbtcDeposit.address)
+      ).to.revertedWith(
+        "Deposit bond auction percentage is below the threshold level"
+      )
+
+      // We need additional 9% to pass the risk manager threshold. To get this
+      // part, we need 22870 seconds to elapse. This is because the auction
+      // length is 86400 seconds (24h) and there is 34% of bonds remaining.
+      // So, additional 9% will be offered after 9/34 * 86400s.
+      await increaseTime(22870)
+
       await riskManagerV1.notifyLiquidation(tbtcDeposit.address)
 
       const auctionAddress = await riskManagerV1.depositToAuction(


### PR DESCRIPTION
Closes #75 

The risk manager should not open an auction for a deposit if the deposit's bond auction offers a bond percentage lower than a `bondAuctionThreshold`.

This is because the risk manager should open a coverage pool auction for only those deposits that nobody else is willing to purchase. It is expected that arbitrage bots will purchase signer bonds for most of the liquidated tBTC deposits before the risk manager will be required to open an auction.

The `bondAuctionThreshold` parameter can be changed by the governance after preserving the governance delay.

This pull request also gets rid of the `collateralizationThreshold` which was the first approach of the aforementioned requirement.