### PR TITLE
Added self-deposit safeguard

### DIFF
--- a/contracts/AssetPool.sol
+++ b/contracts/AssetPool.sol
@@ -274,6 +274,8 @@ contract AssetPool is Ownable {
     }
 
     function _deposit(address depositor, uint256 amount) internal {
+        require(depositor != address(this), "Self-deposit not allowed");
+
         rewardsPool.withdraw();
 
         uint256 covSupply = underwriterToken.totalSupply();


### PR DESCRIPTION
Closes: #59 

Several high-profile tokens do not decrease the approval on `transferFrom` if the
caller is the spender. For example, [UNI](https://etherscan.io/address/0x1f9840a85d5af5bf1d1762f925bdaddc4201f984#code) is not even checking the allowance if
`spender == src`:
```
function transferFrom(address src, address dst, uint rawAmount) external returns (bool) {
  address spender = msg.sender;
   // (...)

  if (spender != src && spenderAllowance != uint96(-1)) {
    // update allowance
  }

  _transferTokens(src, dst, amount);
  return true;
}
```

If `collateralToken` were one of these tokens, `receiveApproval` could be used to
mint unlimited number of COV and made investments of underwriters worthless:

```
receiveApproval(
    AssetPool_address,
    UNI.balanceOf(AssetPool_address),
    UNI_address, ""
)
```
calls
```
UNI.safeTransferFrom(
    AssetPool_address,
    AssetPool_address,
    UNI.balanceOf(AssetPool_address)
)
```
in `_deposit` and `spender == src` and COV tokens can be minted.

This vulnerability was fixed in c205f56 but we are adding an additional safeguard in
`_deposit` making sure Asset Pool can not self-deposit as there is no scenario
in the system where that would happen.

This scenario could not happen in v1 of coverage pools with a single-asset pool for KEEP
but we are fixing it regardless, for future multi-asset implementation for v2.