### PR TITLE
Validate chain ID for every permit call

### DIFF
--- a/contracts/ERC20WithPermit.sol
+++ b/contracts/ERC20WithPermit.sol
@@ -33,23 +33,24 @@ import "./interfaces/IERC20WithPermit.sol";
 contract ERC20WithPermit is Ownable, IERC20WithPermit {
     using SafeMath for uint256;
 
-    uint8 public constant decimals = 18;
-
-    string public name;
-    string public symbol;
-
-    uint256 public override totalSupply;
     mapping(address => uint256) public override balanceOf;
     mapping(address => mapping(address => uint256)) public override allowance;
 
-    uint256 public cachedChainId;
-    bytes32 public cachedDomainSeparator;
+    mapping(address => uint256) public override nonces;
+
+    uint256 public immutable cachedChainId;
+    bytes32 public immutable cachedDomainSeparator;
 
     // keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
     bytes32 public constant override PERMIT_TYPEHASH =
         0x6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c9;
 
-    mapping(address => uint256) public override nonces;
+    uint256 public override totalSupply;
+
+    string public name;
+    string public symbol;
+
+    uint8 public constant decimals = 18;
 
     constructor(string memory _name, string memory _symbol) {
         name = _name;

--- a/contracts/ERC20WithPermit.sol
+++ b/contracts/ERC20WithPermit.sol
@@ -42,32 +42,21 @@ contract ERC20WithPermit is Ownable, IERC20WithPermit {
     mapping(address => uint256) public override balanceOf;
     mapping(address => mapping(address => uint256)) public override allowance;
 
-    bytes32 public override DOMAIN_SEPARATOR;
+    uint256 public cachedChainId;
+    bytes32 public cachedDomainSeparator;
+
     // keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
     bytes32 public constant override PERMIT_TYPEHASH =
         0x6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c9;
+
     mapping(address => uint256) public override nonces;
 
     constructor(string memory _name, string memory _symbol) {
         name = _name;
         symbol = _symbol;
 
-        uint256 chainId;
-        /* solhint-disable-next-line no-inline-assembly */
-        assembly {
-            chainId := chainid()
-        }
-        DOMAIN_SEPARATOR = keccak256(
-            abi.encode(
-                keccak256(
-                    "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
-                ),
-                keccak256(bytes(name)),
-                keccak256(bytes("1")),
-                chainId,
-                address(this)
-            )
-        );
+        cachedChainId = chainId();
+        cachedDomainSeparator = buildDomainSeparator();
     }
 
     function transfer(address recipient, uint256 amount)
@@ -133,7 +122,7 @@ contract ERC20WithPermit is Ownable, IERC20WithPermit {
             keccak256(
                 abi.encodePacked(
                     "\x19\x01",
-                    DOMAIN_SEPARATOR,
+                    DOMAIN_SEPARATOR(),
                     keccak256(
                         abi.encode(
                             PERMIT_TYPEHASH,
@@ -177,6 +166,15 @@ contract ERC20WithPermit is Ownable, IERC20WithPermit {
         _burn(account, amount);
     }
 
+    /* solhint-disable-next-line func-name-mixedcase */
+    function DOMAIN_SEPARATOR() public view override returns (bytes32) {
+        if (chainId() == cachedChainId) {
+            return cachedDomainSeparator;
+        } else {
+            return buildDomainSeparator();
+        }
+    }
+
     function _burn(address account, uint256 amount) internal {
         balanceOf[account] = balanceOf[account].sub(
             amount,
@@ -210,5 +208,27 @@ contract ERC20WithPermit is Ownable, IERC20WithPermit {
         require(spender != address(0), "Approve to the zero address");
         allowance[owner][spender] = amount;
         emit Approval(owner, spender, amount);
+    }
+
+    function buildDomainSeparator() private view returns (bytes32) {
+        return
+            keccak256(
+                abi.encode(
+                    keccak256(
+                        "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+                    ),
+                    keccak256(bytes(name)),
+                    keccak256(bytes("1")),
+                    chainId(),
+                    address(this)
+                )
+            );
+    }
+
+    function chainId() private pure returns (uint256 id) {
+        /* solhint-disable-next-line no-inline-assembly */
+        assembly {
+            id := chainid()
+        }
     }
 }


### PR DESCRIPTION
Closes: #61

Calling `UnderwriterToken.permit` allows an asset holder to move tokens on behalf
of another user by using a signature. The lack of chain ID verification on every
signature could enable an attacker to withdraw rewards multiple times on behalf
of someone else if the chain was forked with a different chain ID.

The chain ID was read only at the deployment time and `DOMAIN_SEPARATOR` was
constructed based on that value. It could happen that the forked chain had
another chain ID, and given that we were not performing chain ID verification
for each permit call, some transactions could be replayed. The same issue
is in LP token v2 version this code is based on.

To address this problem, chain ID and `DOMAIN_SEPARATOR` constructed
for the given chain ID are cached and chain ID is validated for every permit
call. In case the cached value does not match the current one, a new
`DOMAIN_SEPARATOR` is constructed based on the current chain ID value.