### PR TITLE
Risk manager does not allow to be notified twice about the same deposit

### DIFF
--- a/contracts/RiskManagerV1.sol
+++ b/contracts/RiskManagerV1.sol
@@ -162,15 +162,15 @@ contract RiskManagerV1 is Auctioneer, Ownable {
             "Address is not a deposit contract"
         );
 
-        require(
-            depositToAuction[depositAddress] == address(0),
-            "Already notified on the deposit in liquidation"
-        );
-
         IDeposit deposit = IDeposit(depositAddress);
         require(
             deposit.currentState() == DEPOSIT_LIQUIDATION_IN_PROGRESS_STATE,
             "Deposit is not in liquidation state"
+        );
+
+        require(
+            depositToAuction[depositAddress] == address(0),
+            "Already notified on the deposit in liquidation"
         );
 
         require(

--- a/contracts/RiskManagerV1.sol
+++ b/contracts/RiskManagerV1.sol
@@ -164,7 +164,7 @@ contract RiskManagerV1 is Auctioneer, Ownable {
 
         require(
             depositToAuction[depositAddress] == address(0),
-            "Already notified about the deposit"
+            "Already notified on the deposit in liquidation"
         );
 
         IDeposit deposit = IDeposit(depositAddress);

--- a/contracts/RiskManagerV1.sol
+++ b/contracts/RiskManagerV1.sol
@@ -162,6 +162,11 @@ contract RiskManagerV1 is Auctioneer, Ownable {
             "Address is not a deposit contract"
         );
 
+        require(
+            depositToAuction[depositAddress] == address(0),
+            "Already notified about the deposit"
+        );
+
         IDeposit deposit = IDeposit(depositAddress);
         require(
             deposit.currentState() == DEPOSIT_LIQUIDATION_IN_PROGRESS_STATE,
@@ -187,6 +192,7 @@ contract RiskManagerV1 is Auctioneer, Ownable {
             return;
         }
 
+        // slither-disable-next-line reentrancy-no-eth
         address auctionAddress =
             createAuction(tbtcToken, lotSizeTbtc, auctionLength);
         depositToAuction[depositAddress] = auctionAddress;

--- a/test/RiskManagerV1.test.js
+++ b/test/RiskManagerV1.test.js
@@ -133,7 +133,7 @@ describe("RiskManagerV1", () => {
                 riskManagerV1
                   .connect(notifier)
                   .notifyLiquidation(depositStub.address)
-              ).to.be.revertedWith("Already notified about the deposit")
+              ).to.be.revertedWith("Already notified on the deposit in liquidation")
             })
           })
 

--- a/test/RiskManagerV1.test.js
+++ b/test/RiskManagerV1.test.js
@@ -123,6 +123,20 @@ describe("RiskManagerV1", () => {
         })
 
         context("when deposit is at the bond auction threshold", () => {
+          context("when already notified about the deposit", () => {
+            beforeEach(async () => {
+              await notifyLiquidation()
+            })
+
+            it("should revert", async () => {
+              await expect(
+                riskManagerV1
+                  .connect(notifier)
+                  .notifyLiquidation(depositStub.address)
+              ).to.be.revertedWith("Already notified about the deposit")
+            })
+          })
+
           context("when the surplus pool is empty", () => {
             let notifyLiquidationTx
             let auctionAddress

--- a/test/RiskManagerV1.test.js
+++ b/test/RiskManagerV1.test.js
@@ -133,7 +133,9 @@ describe("RiskManagerV1", () => {
                 riskManagerV1
                   .connect(notifier)
                   .notifyLiquidation(depositStub.address)
-              ).to.be.revertedWith("Already notified on the deposit in liquidation")
+              ).to.be.revertedWith(
+                "Already notified on the deposit in liquidation"
+              )
             })
           })
 


### PR DESCRIPTION
Closes: #95 

It was possible to notify risk manager about the liquidation of the same
deposit twice and opening multiple auctions. Fixing it now.