### PR TITLE
Validating if portionToSeize is within the range

### DIFF
--- a/contracts/CoveragePool.sol
+++ b/contracts/CoveragePool.sol
@@ -166,6 +166,12 @@ contract CoveragePool is Ownable {
         external
         onlyApprovedRiskManager
     {
+        require(
+            portionToSeize > 0 &&
+                portionToSeize <= CoveragePoolConstants.FLOATING_POINT_DIVISOR,
+            "Portion to seize is not within the range (0, 1]"
+        );
+
         assetPool.claim(recipient, amountToSeize(portionToSeize));
     }
 

--- a/test/CoveragePool.test.js
+++ b/test/CoveragePool.test.js
@@ -440,6 +440,27 @@ describe("CoveragePool", () => {
           amountSeized
         )
       })
+
+      it("should not allow to seize zero portion of the coverage pool", async () => {
+        const portionToSeize = 0
+
+        await expect(
+          coveragePool
+            .connect(riskManager)
+            .seizeFunds(recipient.address, portionToSeize)
+        ).to.be.revertedWith("Portion to seize is not within the range (0, 1]")
+      })
+
+      it("should not allow to seize more than a pool has", async () => {
+        // actual bounds are (0, 1]. to1e18(1) was used to mimic FLOATING_POINT_DIVISOR
+        const portionToSeize = to1e18(1) + 1
+
+        await expect(
+          coveragePool
+            .connect(riskManager)
+            .seizeFunds(recipient.address, portionToSeize)
+        ).to.be.revertedWith("Portion to seize is not within the range (0, 1]")
+      })
     })
   })
 })


### PR DESCRIPTION
Ref https://github.com/keep-network/coverage-pools/issues/102

Added validation of portion to seize from the coverage pool. It should be within `0 > portionToSeize >= 1` multiplied by `FLOATING_POINT_DIVISOR` for precision purposes.