### PR TITLE
Standardise solidity version to 0.8.4

### DIFF
--- a/contracts/AssetPool.sol
+++ b/contracts/AssetPool.sol
@@ -175,7 +175,7 @@ contract AssetPool is Ownable, IAssetPool {
             "Underwriter token amount must be greater than 0"
         );
 
-        pending = pending + covAmount;
+        pending += covAmount;
         pendingWithdrawal[msg.sender] = pending;
         /* solhint-disable not-rely-on-time */
         withdrawalInitiatedTimestamp[msg.sender] = block.timestamp;

--- a/contracts/AssetPool.sol
+++ b/contracts/AssetPool.sol
@@ -16,7 +16,6 @@ pragma solidity 0.8.4;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import "@openzeppelin/contracts/utils/math/SafeMath.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
 import "./interfaces/IAssetPool.sol";
@@ -35,7 +34,6 @@ import "./GovernanceUtils.sol";
 contract AssetPool is Ownable, IAssetPool {
     using SafeERC20 for IERC20;
     using SafeERC20 for UnderwriterToken;
-    using SafeMath for uint256;
 
     IERC20 public collateralToken;
     UnderwriterToken public underwriterToken;
@@ -106,7 +104,7 @@ contract AssetPool is Ownable, IAssetPool {
         require(changeInitiatedTimestamp > 0, "Change not initiated");
         require(
             /* solhint-disable-next-line not-rely-on-time */
-            block.timestamp.sub(changeInitiatedTimestamp) >=
+            block.timestamp - changeInitiatedTimestamp >=
                 withdrawalGovernanceDelay(),
             "Governance delay has not elapsed"
         );
@@ -177,7 +175,7 @@ contract AssetPool is Ownable, IAssetPool {
             "Underwriter token amount must be greater than 0"
         );
 
-        pending = pending.add(covAmount);
+        pending = pending + covAmount;
         pendingWithdrawal[msg.sender] = pending;
         /* solhint-disable not-rely-on-time */
         withdrawalInitiatedTimestamp[msg.sender] = block.timestamp;
@@ -206,15 +204,14 @@ contract AssetPool is Ownable, IAssetPool {
         uint256 initiatedAt = withdrawalInitiatedTimestamp[underwriter];
         require(initiatedAt > 0, "No withdrawal initiated for the underwriter");
 
-        uint256 withdrawalDelayEndTimestamp = initiatedAt.add(withdrawalDelay);
+        uint256 withdrawalDelayEndTimestamp = initiatedAt + withdrawalDelay;
         require(
             withdrawalDelayEndTimestamp < block.timestamp,
             "Withdrawal delay has not elapsed"
         );
 
         require(
-            withdrawalDelayEndTimestamp.add(withdrawalTimeout) >=
-                block.timestamp,
+            withdrawalDelayEndTimestamp + withdrawalTimeout >= block.timestamp,
             "Withdrawal timeout elapsed"
         );
 
@@ -228,8 +225,7 @@ contract AssetPool is Ownable, IAssetPool {
 
         uint256 collateralBalance = collateralToken.balanceOf(address(this));
 
-        uint256 amountToWithdraw =
-            covAmount.mul(collateralBalance).div(covSupply);
+        uint256 amountToWithdraw = (covAmount * collateralBalance) / covSupply;
 
         emit WithdrawalCompleted(
             underwriter,
@@ -284,7 +280,7 @@ contract AssetPool is Ownable, IAssetPool {
         uint256 collateralBalance = collateralToken.balanceOf(address(this));
 
         uint256 collateralToTransfer =
-            covAmount.mul(collateralBalance).div(covSupply);
+            (covAmount * collateralBalance) / covSupply;
 
         collateralToken.safeApprove(
             address(newAssetPool),
@@ -436,7 +432,7 @@ contract AssetPool is Ownable, IAssetPool {
     ///         to wait longer before finalizing the update.
     /// @return The withdrawal governance delay in seconds
     function withdrawalGovernanceDelay() public view returns (uint256) {
-        return withdrawalDelay.add(withdrawalTimeout).add(2 days);
+        return withdrawalDelay + withdrawalTimeout + 2 days;
     }
 
     function _deposit(address depositor, uint256 amount) internal {
@@ -451,7 +447,7 @@ contract AssetPool is Ownable, IAssetPool {
         if (covSupply == 0) {
             toMint = amount;
         } else {
-            toMint = amount.mul(covSupply).div(collateralBalance);
+            toMint = (amount * covSupply) / collateralBalance;
         }
         underwriterToken.mint(depositor, toMint);
         collateralToken.safeTransferFrom(depositor, address(this), amount);

--- a/contracts/AssetPool.sol
+++ b/contracts/AssetPool.sol
@@ -12,11 +12,11 @@
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity <0.9.0;
+pragma solidity 0.8.4;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
-import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "@openzeppelin/contracts/utils/math/SafeMath.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
 import "./interfaces/IAssetPool.sol";

--- a/contracts/Auction.sol
+++ b/contracts/Auction.sol
@@ -20,7 +20,6 @@ import "./CoveragePoolConstants.sol";
 import "@openzeppelin/contracts/utils/math/Math.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import "@openzeppelin/contracts/utils/math/SafeMath.sol";
 
 /// @title Auction
 /// @notice A contract to run a linear falling-price auction against a diverse
@@ -37,7 +36,6 @@ import "@openzeppelin/contracts/utils/math/SafeMath.sol";
 ///       profitable to close.
 contract Auction is IAuction {
     using SafeERC20 for IERC20;
-    using SafeMath for uint256;
 
     struct AuctionStorage {
         IERC20 tokenAccepted;
@@ -144,22 +142,20 @@ contract Auction is IAuction {
         );
 
         uint256 portionToSeize =
-            amountOnOffer.mul(amountToTransfer).div(self.amountOutstanding);
+            (amountOnOffer * amountToTransfer) / self.amountOutstanding;
 
         if (!_isAuctionOver() && amountToTransfer != self.amountOutstanding) {
             // Time passed since the auction start or the last takeOffer call
             // with a partial fill.
             uint256 timePassed =
                 /* solhint-disable-next-line not-rely-on-time */
-                block.timestamp.sub(self.startTime).sub(self.startTimeOffset);
+                block.timestamp - self.startTime - self.startTimeOffset;
 
             // Ratio of the auction's amount included in this takeOffer call to
             // the whole outstanding auction amount.
             uint256 ratioAmountPaid =
-                CoveragePoolConstants
-                    .FLOATING_POINT_DIVISOR
-                    .mul(amountToTransfer)
-                    .div(self.amountOutstanding);
+                (CoveragePoolConstants.FLOATING_POINT_DIVISOR *
+                    amountToTransfer) / self.amountOutstanding;
             // We will shift the start time offset and increase the velocity pool
             // depleting rate proportionally to the fraction of the outstanding
             // amount paid in this function call so that the auction can offer
@@ -167,18 +163,17 @@ contract Auction is IAuction {
             // taker has.
             //
             //slither-disable-next-line divide-before-multiply
-            self.startTimeOffset = self.startTimeOffset.add(
-                timePassed.mul(ratioAmountPaid).div(
-                    CoveragePoolConstants.FLOATING_POINT_DIVISOR
-                )
-            );
-            self.velocityPoolDepletingRate = CoveragePoolConstants
-                .FLOATING_POINT_DIVISOR
-                .mul(self.auctionLength)
-                .div(self.auctionLength.sub(self.startTimeOffset));
+            self.startTimeOffset =
+                self.startTimeOffset +
+                ((timePassed * ratioAmountPaid) /
+                    CoveragePoolConstants.FLOATING_POINT_DIVISOR);
+            self.velocityPoolDepletingRate =
+                (CoveragePoolConstants.FLOATING_POINT_DIVISOR *
+                    self.auctionLength) /
+                (self.auctionLength - self.startTimeOffset);
         }
 
-        self.amountOutstanding = self.amountOutstanding.sub(amountToTransfer);
+        self.amountOutstanding = self.amountOutstanding - amountToTransfer;
 
         // inform auctioneer of proceeds and winner. the auctioneer seizes funds
         // from the collateral pool in the name of the winner, and controls all
@@ -210,9 +205,9 @@ contract Auction is IAuction {
 
     /// @notice How much of the collateral pool can currently be purchased at
     ///         auction, across all assets.
-    /// @dev _onOffer().div(FLOATING_POINT_DIVISOR) returns a portion of the
+    /// @dev _onOffer() / FLOATING_POINT_DIVISOR) returns a portion of the
     ///      collateral pool. Ex. if 35% available of the collateral pool,
-    ///      then _onOffer().div(FLOATING_POINT_DIVISOR) returns 0.35
+    ///      then _onOffer() / FLOATING_POINT_DIVISOR) returns 0.35
     /// @return the ratio of the collateral pool currently on offer
     function onOffer() external view override returns (uint256, uint256) {
         return (_onOffer(), CoveragePoolConstants.FLOATING_POINT_DIVISOR);
@@ -223,7 +218,7 @@ contract Auction is IAuction {
     }
 
     function amountTransferred() external view returns (uint256) {
-        return self.amountDesired.sub(self.amountOutstanding);
+        return self.amountDesired - self.amountOutstanding;
     }
 
     function isOpen() external view returns (bool) {
@@ -252,13 +247,12 @@ contract Auction is IAuction {
 
         return
             /* solhint-disable-next-line not-rely-on-time */
-            (block.timestamp.sub(self.startTime.add(self.startTimeOffset)))
-                .mul(self.velocityPoolDepletingRate)
-                .div(self.auctionLength);
+            ((block.timestamp - (self.startTime + self.startTimeOffset)) *
+                self.velocityPoolDepletingRate) / self.auctionLength;
     }
 
     function _isAuctionOver() internal view returns (bool) {
         /* solhint-disable-next-line not-rely-on-time */
-        return block.timestamp >= self.startTime.add(self.auctionLength);
+        return block.timestamp >= self.startTime + self.auctionLength;
     }
 }

--- a/contracts/Auction.sol
+++ b/contracts/Auction.sol
@@ -234,7 +234,8 @@ contract Auction is IAuction {
     ///      after an auction has closed.
     function harikari() internal {
         require(!isMasterContract, "Master contract can not harikari");
-        address payable addr = address(uint160(address(self.auctioneer)));
+        address payable addr =
+            payable(address(uint160(address(self.auctioneer))));
         delete self;
         selfdestruct(addr);
     }

--- a/contracts/Auction.sol
+++ b/contracts/Auction.sol
@@ -173,7 +173,7 @@ contract Auction is IAuction {
                 (self.auctionLength - self.startTimeOffset);
         }
 
-        self.amountOutstanding = self.amountOutstanding - amountToTransfer;
+        self.amountOutstanding -= amountToTransfer;
 
         // inform auctioneer of proceeds and winner. the auctioneer seizes funds
         // from the collateral pool in the name of the winner, and controls all

--- a/contracts/Auction.sol
+++ b/contracts/Auction.sol
@@ -12,15 +12,15 @@
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity <0.9.0;
+pragma solidity 0.8.4;
 
 import "./Auctioneer.sol";
 import "./interfaces/IAuction.sol";
 import "./CoveragePoolConstants.sol";
-import "@openzeppelin/contracts/math/Math.sol";
+import "@openzeppelin/contracts/utils/math/Math.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
-import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "@openzeppelin/contracts/utils/math/SafeMath.sol";
 
 /// @title Auction
 /// @notice A contract to run a linear falling-price auction against a diverse

--- a/contracts/AuctionBidder.sol
+++ b/contracts/AuctionBidder.sol
@@ -16,15 +16,12 @@ pragma solidity 0.8.4;
 
 import "./Auction.sol";
 import "./CoveragePool.sol";
-import "@openzeppelin/contracts/utils/math/SafeMath.sol";
 
 /// @title AuctionBidder
 /// @notice A contract for auction bidders for buying coverage pool auctions. This
 ///         contract offers additional features for bidders to decide if their
 ///         requirements for making a purchase are satisfied.
 contract AuctionBidder {
-    using SafeMath for uint256;
-
     CoveragePool public coveragePool;
 
     constructor(CoveragePool _coveragePool) {
@@ -56,7 +53,7 @@ contract AuctionBidder {
         uint256 amountToPay = Math.min(amount, auctionAmountOutstanding);
         (uint256 amountOnOffer, ) = auction.onOffer();
         uint256 portionToSeize =
-            amountOnOffer.mul(amountToPay).div(auctionAmountOutstanding);
+            (amountOnOffer * amountToPay) / auctionAmountOutstanding;
 
         uint256 amountToSeize = coveragePool.amountToSeize(portionToSeize);
 

--- a/contracts/AuctionBidder.sol
+++ b/contracts/AuctionBidder.sol
@@ -12,11 +12,11 @@
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity <0.9.0;
+pragma solidity 0.8.4;
 
 import "./Auction.sol";
 import "./CoveragePool.sol";
-import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/utils/math/SafeMath.sol";
 
 /// @title AuctionBidder
 /// @notice A contract for auction bidders for buying coverage pool auctions. This

--- a/contracts/Auctioneer.sol
+++ b/contracts/Auctioneer.sol
@@ -12,13 +12,13 @@
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity <0.9.0;
+pragma solidity 0.8.4;
 
 import "./CloneFactory.sol";
 import "./Auction.sol";
 import "./CoveragePool.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/utils/math/SafeMath.sol";
 
 /// @title Auctioneer
 /// @notice Factory for the creation of new auction clones and receiving proceeds.

--- a/contracts/Auctioneer.sol
+++ b/contracts/Auctioneer.sol
@@ -100,7 +100,7 @@ contract Auctioneer is CloneFactory {
 
             emit AuctionClosed(msg.sender);
             delete openAuctions[msg.sender];
-            openAuctionsCount = openAuctionsCount - 1;
+            openAuctionsCount -= 1;
         }
     }
 
@@ -129,7 +129,7 @@ contract Auctioneer is CloneFactory {
         );
 
         openAuctions[cloneAddress] = true;
-        openAuctionsCount = openAuctionsCount + 1;
+        openAuctionsCount += 1;
 
         emit AuctionCreated(
             address(tokenAccepted),
@@ -159,7 +159,7 @@ contract Auctioneer is CloneFactory {
 
         emit AuctionClosed(auctionAddress);
         delete openAuctions[auctionAddress];
-        openAuctionsCount = openAuctionsCount - 1;
+        openAuctionsCount -= 1;
 
         return amountTransferred;
     }

--- a/contracts/Auctioneer.sol
+++ b/contracts/Auctioneer.sol
@@ -18,7 +18,6 @@ import "./CloneFactory.sol";
 import "./Auction.sol";
 import "./CoveragePool.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "@openzeppelin/contracts/utils/math/SafeMath.sol";
 
 /// @title Auctioneer
 /// @notice Factory for the creation of new auction clones and receiving proceeds.
@@ -27,8 +26,6 @@ import "@openzeppelin/contracts/utils/math/SafeMath.sol";
 ///       This means that we only need to deploy the auction contracts once.
 ///       The auctioneer provides clean state for every new auction clone.
 contract Auctioneer is CloneFactory {
-    using SafeMath for uint256;
-
     // Holds the address of the auction contract
     // which will be used as a master contract for cloning.
     address public masterAuction;
@@ -103,7 +100,7 @@ contract Auctioneer is CloneFactory {
 
             emit AuctionClosed(msg.sender);
             delete openAuctions[msg.sender];
-            openAuctionsCount = openAuctionsCount.sub(1);
+            openAuctionsCount = openAuctionsCount - 1;
         }
     }
 
@@ -132,7 +129,7 @@ contract Auctioneer is CloneFactory {
         );
 
         openAuctions[cloneAddress] = true;
-        openAuctionsCount = openAuctionsCount.add(1);
+        openAuctionsCount = openAuctionsCount + 1;
 
         emit AuctionCreated(
             address(tokenAccepted),
@@ -162,7 +159,7 @@ contract Auctioneer is CloneFactory {
 
         emit AuctionClosed(auctionAddress);
         delete openAuctions[auctionAddress];
-        openAuctionsCount = openAuctionsCount.sub(1);
+        openAuctionsCount = openAuctionsCount - 1;
 
         return amountTransferred;
     }

--- a/contracts/CloneFactory.sol
+++ b/contracts/CloneFactory.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.7.6;
+pragma solidity 0.8.4;
 
 /*
 The MIT License (MIT)

--- a/contracts/CoveragePool.sol
+++ b/contracts/CoveragePool.sol
@@ -20,7 +20,6 @@ import "./GovernanceUtils.sol";
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "@openzeppelin/contracts/utils/math/SafeMath.sol";
 
 import "./interfaces/IAssetPoolUpgrade.sol";
 
@@ -31,8 +30,6 @@ import "./interfaces/IAssetPoolUpgrade.sol";
 /// @dev Coverage pool contract is owned by the governance. Coverage pool is the
 ///      owner of the asset pool contract.
 contract CoveragePool is Ownable {
-    using SafeMath for uint256;
-
     AssetPool public assetPool;
     IERC20 public collateralToken;
 
@@ -97,7 +94,7 @@ contract CoveragePool is Ownable {
         );
         require(
             /* solhint-disable-next-line not-rely-on-time */
-            block.timestamp.sub(riskManagerApprovalTimestamps[riskManager]) >=
+            block.timestamp - riskManagerApprovalTimestamps[riskManager] >=
                 assetPool.withdrawalGovernanceDelay(),
             "Risk manager governance delay has not elapsed"
         );
@@ -216,9 +213,7 @@ contract CoveragePool is Ownable {
         returns (uint256)
     {
         return
-            collateralToken
-                .balanceOf(address(assetPool))
-                .mul(portionToSeize)
-                .div(CoveragePoolConstants.FLOATING_POINT_DIVISOR);
+            (collateralToken.balanceOf(address(assetPool)) * portionToSeize) /
+            CoveragePoolConstants.FLOATING_POINT_DIVISOR;
     }
 }

--- a/contracts/CoveragePool.sol
+++ b/contracts/CoveragePool.sol
@@ -12,14 +12,14 @@
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity <0.9.0;
+pragma solidity 0.8.4;
 
 import "./AssetPool.sol";
 import "./CoveragePoolConstants.sol";
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/utils/math/SafeMath.sol";
 
 import "./interfaces/IAssetPoolUpgrade.sol";
 

--- a/contracts/CoveragePoolConstants.sol
+++ b/contracts/CoveragePoolConstants.sol
@@ -12,7 +12,7 @@
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity <0.9.0;
+pragma solidity 0.8.4;
 
 library CoveragePoolConstants {
     // This divisor is for precision purposes only. We use this divisor around

--- a/contracts/ERC20WithPermit.sol
+++ b/contracts/ERC20WithPermit.sol
@@ -12,9 +12,9 @@
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity <0.8.0;
+pragma solidity 0.8.4;
 
-import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/utils/math/SafeMath.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
 import "./interfaces/IERC20WithPermit.sol";

--- a/contracts/ERC20WithPermit.sol
+++ b/contracts/ERC20WithPermit.sol
@@ -74,7 +74,7 @@ contract ERC20WithPermit is Ownable, IERC20WithPermit {
         address recipient,
         uint256 amount
     ) external override returns (bool) {
-        if (allowance[sender][msg.sender] != uint256(-1)) {
+        if (allowance[sender][msg.sender] != type(uint256).max) {
             _approve(
                 sender,
                 msg.sender,
@@ -226,7 +226,7 @@ contract ERC20WithPermit is Ownable, IERC20WithPermit {
             );
     }
 
-    function chainId() private pure returns (uint256 id) {
+    function chainId() private view returns (uint256 id) {
         /* solhint-disable-next-line no-inline-assembly */
         assembly {
             id := chainid()

--- a/contracts/GovernanceUtils.sol
+++ b/contracts/GovernanceUtils.sol
@@ -14,11 +14,7 @@
 
 pragma solidity <0.9.0;
 
-import "@openzeppelin/contracts/math/SafeMath.sol";
-
 library GovernanceUtils {
-    using SafeMath for uint256;
-
     /// @notice Gets the time remaining until the governable parameter update
     ///         can be committed.
     /// @param changeTimestamp Timestamp indicating the beginning of the change.
@@ -31,11 +27,11 @@ library GovernanceUtils {
     {
         require(changeTimestamp > 0, "Change not initiated");
         /* solhint-disable-next-line not-rely-on-time */
-        uint256 elapsed = block.timestamp.sub(changeTimestamp);
+        uint256 elapsed = block.timestamp - changeTimestamp;
         if (elapsed >= delay) {
             return 0;
         } else {
-            return delay.sub(elapsed);
+            return delay - elapsed;
         }
     }
 }

--- a/contracts/RewardsPool.sol
+++ b/contracts/RewardsPool.sol
@@ -12,12 +12,12 @@
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity <0.9.0;
+pragma solidity 0.8.4;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
-import "@openzeppelin/contracts/math/Math.sol";
-import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "@openzeppelin/contracts/utils/math/Math.sol";
+import "@openzeppelin/contracts/utils/math/SafeMath.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
 import "./AssetPool.sol";

--- a/contracts/RewardsPool.sol
+++ b/contracts/RewardsPool.sol
@@ -17,7 +17,6 @@ pragma solidity 0.8.4;
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/utils/math/Math.sol";
-import "@openzeppelin/contracts/utils/math/SafeMath.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
 import "./AssetPool.sol";
@@ -29,7 +28,6 @@ import "./AssetPool.sol";
 ///         tokens.
 contract RewardsPool is Ownable {
     using SafeERC20 for IERC20;
-    using SafeMath for uint256;
 
     uint256 public constant DURATION = 7 days;
 
@@ -70,13 +68,13 @@ contract RewardsPool is Ownable {
         if (block.timestamp >= intervalFinish) {
             // see https://github.com/crytic/slither/issues/844
             // slither-disable-next-line divide-before-multiply
-            rewardRate = reward.div(DURATION);
+            rewardRate = reward / DURATION;
         } else {
-            uint256 remaining = intervalFinish.sub(block.timestamp);
-            uint256 leftover = remaining.mul(rewardRate);
-            rewardRate = reward.add(leftover).div(DURATION);
+            uint256 remaining = intervalFinish - block.timestamp;
+            uint256 leftover = remaining * rewardRate;
+            rewardRate = (reward + leftover) / DURATION;
         }
-        intervalFinish = block.timestamp.add(DURATION);
+        intervalFinish = block.timestamp + DURATION;
         lastUpdateTime = block.timestamp;
         /* solhint-enable avoid-low-level-calls */
 
@@ -97,9 +95,8 @@ contract RewardsPool is Ownable {
     /// tokens.
     function earned() public view returns (uint256) {
         return
-            rewardAccumulated.add(
-                lastTimeRewardApplicable().sub(lastUpdateTime).mul(rewardRate)
-            );
+            rewardAccumulated +
+            ((lastTimeRewardApplicable() - lastUpdateTime) * rewardRate);
     }
 
     /// @notice Returns the timestamp at which a reward was last time applicable.

--- a/contracts/RiskManagerV1.sol
+++ b/contracts/RiskManagerV1.sol
@@ -12,14 +12,14 @@
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity <0.9.0;
+pragma solidity 0.8.4;
 
 import "./Auctioneer.sol";
 import "./Auction.sol";
 import "./CoveragePoolConstants.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
-import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "@openzeppelin/contracts/utils/math/SafeMath.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "./interfaces/IRiskManager.sol";
 

--- a/contracts/RiskManagerV1.sol
+++ b/contracts/RiskManagerV1.sol
@@ -199,7 +199,7 @@ contract RiskManagerV1 is IRiskManager, Auctioneer, Ownable {
         // If the surplus can cover the deposit liquidation cost, liquidate
         // that deposit directly without the auction process.
         if (tbtcSurplus >= lotSizeTbtc) {
-            tbtcSurplus = tbtcSurplus - lotSizeTbtc;
+            tbtcSurplus -= lotSizeTbtc;
             liquidateDeposit(deposit);
             return;
         }
@@ -234,7 +234,7 @@ contract RiskManagerV1 is IRiskManager, Auctioneer, Ownable {
 
         // Add auction's transferred amount to the surplus pool.
         // slither-disable-next-line reentrancy-benign
-        tbtcSurplus = tbtcSurplus + amountTransferred;
+        tbtcSurplus += amountTransferred;
     }
 
     /// @notice Begins the bond auction threshold update process.

--- a/contracts/RiskManagerV1.sol
+++ b/contracts/RiskManagerV1.sol
@@ -170,7 +170,7 @@ contract RiskManagerV1 is IRiskManager, Auctioneer, Ownable {
     /// @param  depositAddress tBTC Deposit address
     function notifyLiquidation(address depositAddress) external {
         require(
-            tbtcDepositToken.exists(uint256(depositAddress)),
+            tbtcDepositToken.exists(uint256(uint160(depositAddress))),
             "Address is not a deposit contract"
         );
 

--- a/contracts/SignerBondsManualSwap.sol
+++ b/contracts/SignerBondsManualSwap.sol
@@ -12,7 +12,7 @@
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity <0.9.0;
+pragma solidity 0.8.4;
 
 import "./interfaces/IRiskManager.sol";
 import "./RiskManagerV1.sol";

--- a/contracts/SignerBondsUniswapV2.sol
+++ b/contracts/SignerBondsUniswapV2.sol
@@ -286,13 +286,15 @@ contract SignerBondsUniswapV2 is ISignerBondsSwapStrategy, Ownable {
 
         return
             address(
-                uint256(
-                    keccak256(
-                        abi.encodePacked(
-                            hex"ff",
-                            factory,
-                            keccak256(abi.encodePacked(token0, token1)),
-                            hex"96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f"
+                uint160(
+                    uint256(
+                        keccak256(
+                            abi.encodePacked(
+                                hex"ff",
+                                factory,
+                                keccak256(abi.encodePacked(token0, token1)),
+                                hex"96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f"
+                            )
                         )
                     )
                 )

--- a/contracts/SignerBondsUniswapV2.sol
+++ b/contracts/SignerBondsUniswapV2.sol
@@ -12,7 +12,7 @@
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity <0.9.0;
+pragma solidity 0.8.4;
 
 import "./interfaces/IRiskManager.sol";
 import "./RiskManagerV1.sol";

--- a/contracts/UnderwriterToken.sol
+++ b/contracts/UnderwriterToken.sol
@@ -12,7 +12,7 @@
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity <0.8.0;
+pragma solidity 0.8.4;
 
 import "./AssetPool.sol";
 

--- a/contracts/interfaces/IAssetPool.sol
+++ b/contracts/interfaces/IAssetPool.sol
@@ -12,7 +12,7 @@
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity <0.9.0;
+pragma solidity 0.8.4;
 
 interface IAssetPool {
     /// @notice Accepts the given amount of collateral token as a deposit and

--- a/contracts/interfaces/IAssetPoolUpgrade.sol
+++ b/contracts/interfaces/IAssetPoolUpgrade.sol
@@ -12,7 +12,7 @@
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity <0.9.0;
+pragma solidity 0.8.4;
 
 interface IAssetPoolUpgrade {
     /// @notice Accepts the given underwriter with collateral tokens amount as a

--- a/contracts/interfaces/IAuction.sol
+++ b/contracts/interfaces/IAuction.sol
@@ -12,7 +12,7 @@
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity <0.9.0;
+pragma solidity 0.8.4;
 
 interface IAuction {
     /// @notice Takes an offer from an auction buyer.

--- a/contracts/interfaces/IERC20WithPermit.sol
+++ b/contracts/interfaces/IERC20WithPermit.sol
@@ -12,7 +12,7 @@
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity <0.9.0;
+pragma solidity 0.8.4;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/contracts/interfaces/IRiskManager.sol
+++ b/contracts/interfaces/IRiskManager.sol
@@ -12,7 +12,7 @@
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity <0.9.0;
+pragma solidity 0.8.4;
 
 /// @title IRiskManager
 interface IRiskManager {

--- a/contracts/interfaces/IUnderwriterToken.sol
+++ b/contracts/interfaces/IUnderwriterToken.sol
@@ -12,7 +12,7 @@
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity <0.9.0;
+pragma solidity 0.8.4;
 
 import "./IERC20WithPermit.sol";
 

--- a/contracts/test/AuctionStub.sol
+++ b/contracts/test/AuctionStub.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity <0.9.0;
+pragma solidity 0.8.4;
 
 import "../interfaces/IAuction.sol";
 

--- a/contracts/test/AuctioneerStub.sol
+++ b/contracts/test/AuctioneerStub.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity <0.9.0;
+pragma solidity 0.8.4;
 
 import "../Auctioneer.sol";
 

--- a/contracts/test/CoveragePoolStub.sol
+++ b/contracts/test/CoveragePoolStub.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity <0.9.0;
+pragma solidity 0.8.4;
 
 contract CoveragePoolStub {
     event FundsSeized(address indexed recipient, uint256 portionToSeize);

--- a/contracts/test/DepositStub.sol
+++ b/contracts/test/DepositStub.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity <0.9.0;
+pragma solidity 0.8.4;
 
-import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 import "../RiskManagerV1.sol";
 

--- a/contracts/test/NewAssetPoolStub.sol
+++ b/contracts/test/NewAssetPoolStub.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
-pragma solidity <0.9.0;
+pragma solidity 0.8.4;
 
 import "../interfaces/IAssetPool.sol";
 import "../interfaces/IAssetPoolUpgrade.sol";
 import "../UnderwriterToken.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 contract NewAssetPoolStub is IAssetPoolUpgrade {
     using SafeERC20 for IERC20;

--- a/contracts/test/RiskManagerV1Stub.sol
+++ b/contracts/test/RiskManagerV1Stub.sol
@@ -6,7 +6,6 @@ import "../RiskManagerV1.sol";
 
 contract RiskManagerV1Stub is RiskManagerV1 {
     using SafeERC20 for IERC20;
-    using SafeMath for uint256;
 
     constructor(
         IERC20 _tbtcToken,
@@ -30,6 +29,6 @@ contract RiskManagerV1Stub is RiskManagerV1 {
 
     function fundTbtcSurplus(uint256 amount) external {
         tbtcToken.safeTransferFrom(msg.sender, address(this), amount);
-        tbtcSurplus = tbtcSurplus.add(amount);
+        tbtcSurplus = tbtcSurplus + amount;
     }
 }

--- a/contracts/test/RiskManagerV1Stub.sol
+++ b/contracts/test/RiskManagerV1Stub.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity <0.9.0;
+pragma solidity 0.8.4;
 
 import "../RiskManagerV1.sol";
 

--- a/contracts/test/SignerBondsUniswapV2Stub.sol
+++ b/contracts/test/SignerBondsUniswapV2Stub.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity <0.9.0;
+pragma solidity 0.8.4;
 
 import "../SignerBondsUniswapV2.sol";
 

--- a/contracts/test/TestToken.sol
+++ b/contracts/test/TestToken.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity <0.9.0;
+pragma solidity 0.8.4;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 

--- a/contracts/test/UniswapV2RouterStub.sol
+++ b/contracts/test/UniswapV2RouterStub.sol
@@ -5,8 +5,6 @@ pragma solidity 0.8.4;
 import "../SignerBondsUniswapV2.sol";
 
 contract UniswapV2RouterStub is IUniswapV2Router {
-    using SafeMath for uint256;
-
     // Settable fake exchange rate is defined here to avoid pair logic complexity.
     // It determines how much tokens can be received for 1 ETH.
     uint256 public exchangeRate = 1;
@@ -37,7 +35,7 @@ contract UniswapV2RouterStub is IUniswapV2Router {
 
         amounts = new uint256[](2);
         amounts[0] = msg.value;
-        amounts[1] = msg.value.mul(exchangeRate).mul(997).div(1000); // simulate 0.3% fee
+        amounts[1] = (msg.value * exchangeRate * 997) / 1000; // simulate 0.3% fee
 
         return amounts;
     }
@@ -51,7 +49,7 @@ contract UniswapV2RouterStub is IUniswapV2Router {
     ) external view override returns (uint256[] memory amounts) {
         amounts = new uint256[](2);
         amounts[0] = amountIn;
-        amounts[1] = amountIn.mul(exchangeRate).mul(997).div(1000); // simulate 0.3% fee
+        amounts[1] = (amountIn * exchangeRate * 997) / 1000; // simulate 0.3% fee
 
         return amounts;
     }

--- a/contracts/test/UniswapV2RouterStub.sol
+++ b/contracts/test/UniswapV2RouterStub.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity <0.9.0;
+pragma solidity 0.8.4;
 
 import "../SignerBondsUniswapV2.sol";
 

--- a/contracts/v2/RewardsPoolV2.sol
+++ b/contracts/v2/RewardsPoolV2.sol
@@ -12,9 +12,9 @@
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity <0.9.0;
+pragma solidity 0.8.4;
 
-import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/utils/math/SafeMath.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
 /// @title RewardTokenMinting

--- a/contracts/v2/RewardsPoolV2.sol
+++ b/contracts/v2/RewardsPoolV2.sol
@@ -14,7 +14,6 @@
 
 pragma solidity 0.8.4;
 
-import "@openzeppelin/contracts/utils/math/SafeMath.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
 /// @title RewardTokenMinting
@@ -27,8 +26,6 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 ///      a specific part of the functionality of the RewardPool and should be
 ///      used only as a RewardPool parent contract.
 abstract contract RewardTokenMinting {
-    using SafeMath for uint256;
-
     // Reward rate per Asset Pool address.
     // Reward rate is 1e18 precision number.
     mapping(address => uint256) public rewardRates;
@@ -48,11 +45,9 @@ abstract contract RewardTokenMinting {
 
     function earned(address assetPool) public view returns (uint256) {
         return
-            rewardRates[assetPool]
-                .mul(
-                tokenPerRateUnit().sub(poolTokenPerRateUnitPaid[assetPool])
-            )
-                .add(poolTokens[assetPool]);
+            rewardRates[assetPool] *
+            (tokenPerRateUnit() - poolTokenPerRateUnitPaid[assetPool]) +
+            poolTokens[assetPool];
     }
 
     function updateReward(address assetPool) internal {
@@ -65,10 +60,9 @@ abstract contract RewardTokenMinting {
 
     function tokenPerRateUnit() internal view returns (uint256) {
         return
-            tokenPerRateUnitAccumulated.add(
-                /* solhint-disable-next-line not-rely-on-time */
-                block.timestamp.sub(lastUpdateTime)
-            );
+            tokenPerRateUnitAccumulated +
+            (/* solhint-disable-next-line not-rely-on-time */
+            block.timestamp - lastUpdateTime);
     }
 }
 

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -3,7 +3,11 @@ require("hardhat-gas-reporter")
 
 module.exports = {
   solidity: {
-    version: "0.7.6",
+    compilers: [
+      {
+        version: "0.8.4",
+      },
+    ],
   },
 
   networks: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@openzeppelin/contracts": "^3.3.0"
+    "@openzeppelin/contracts": "^4.1.0"
   },
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.2",

--- a/test/system/liquidation.test.js
+++ b/test/system/liquidation.test.js
@@ -179,10 +179,10 @@ describeFn("System -- liquidation", () => {
     })
 
     it("should consume a reasonable amount of gas", async () => {
-      await expect(parseInt(tx.gasLimit)).to.be.lessThan(483000)
+      await expect(parseInt(tx.gasLimit)).to.be.lessThan(500000)
 
       const txReceipt = await ethers.provider.getTransactionReceipt(tx.hash)
-      await expect(parseInt(txReceipt.gasUsed)).to.be.lessThan(238000)
+      await expect(parseInt(txReceipt.gasUsed)).to.be.lessThan(243000)
     })
   })
 })

--- a/test/system/uniswap-v2.test.js
+++ b/test/system/uniswap-v2.test.js
@@ -122,7 +122,7 @@ describeFn("System -- swap signer bonds on UniswapV2", () => {
           riskManagerV1.address,
           ethers.utils.parseEther("10"),
           {
-            gasLimit: 200000,
+            gasLimit: 210000,
           }
         )
     })
@@ -159,10 +159,10 @@ describeFn("System -- swap signer bonds on UniswapV2", () => {
     })
 
     it("should consume a reasonable amount of gas", async () => {
-      await expect(parseInt(tx.gasLimit)).to.be.equal(200000)
+      await expect(parseInt(tx.gasLimit)).to.be.equal(210000)
 
       const txReceipt = await ethers.provider.getTransactionReceipt(tx.hash)
-      await expect(parseInt(txReceipt.gasUsed)).to.be.lessThan(175000)
+      await expect(parseInt(txReceipt.gasUsed)).to.be.lessThan(180000)
     })
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -528,10 +528,10 @@
     "@types/sinon-chai" "^3.2.3"
     "@types/web3" "1.0.19"
 
-"@openzeppelin/contracts@^3.3.0":
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-3.4.1.tgz#03c891fec7f93be0ae44ed74e57a122a38732ce7"
-  integrity sha512-cUriqMauq1ylzP2TxePNdPqkwI7Le3Annh4K9rrpvKfSBB/bdW+Iu1ihBaTIABTAAJ85LmKL5SSPPL9ry8d1gQ==
+"@openzeppelin/contracts@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.1.0.tgz#baec89a7f5f73e3d8ea582a78f1980134b605375"
+  integrity sha512-TihZitscnaHNcZgXGj9zDLDyCqjziytB4tMCwXq0XimfWkAjBYyk5/pOsDbbwcavhlc79HhpTEpQcrMnPVa1mw==
 
 "@resolver-engine/core@^0.3.3":
   version "0.3.3"


### PR DESCRIPTION
Closes https://github.com/keep-network/coverage-pools/issues/98

For Solidity upgrade to 0.8.4 this PR also upgrades OZ to 4.1.0 to align with Solidity compiler. Some of the compilation errors had to be changed as well.