### PR TITLE
Linter cleanup

### DIFF
--- a/contracts/CoveragePool.sol
+++ b/contracts/CoveragePool.sol
@@ -154,6 +154,15 @@ contract CoveragePool is Ownable {
         delete approvedRiskManagers[riskManager];
     }
 
+    /// @notice Approves upgradeability of a new asset pool.
+    /// @param _newAssetPool New asset pool
+    function approveNewAssetPoolUpgrade(IAssetPoolUpgrade _newAssetPool)
+        external
+        onlyOwner
+    {
+        assetPool.approveNewAssetPoolUpgrade(_newAssetPool);
+    }
+
     /// @notice Seizes funds from the coverage pool and puts them aside for the
     ///         recipient to withdraw.
     /// @dev `portionToSeize` value was multiplied by `FLOATING_POINT_DIVISOR`
@@ -173,30 +182,6 @@ contract CoveragePool is Ownable {
         );
 
         assetPool.claim(recipient, amountToSeize(portionToSeize));
-    }
-
-    /// @notice Calculates amount of tokens to be seized from the coverage pool.
-    /// @param portionToSeize Portion of the pool to seize in the range (0, 1]
-    ///        multiplied by FLOATING_POINT_DIVISOR.
-    function amountToSeize(uint256 portionToSeize)
-        public
-        view
-        returns (uint256)
-    {
-        return
-            collateralToken
-                .balanceOf(address(assetPool))
-                .mul(portionToSeize)
-                .div(CoveragePoolConstants.FLOATING_POINT_DIVISOR);
-    }
-
-    /// @notice Approves upgradeability of a new asset pool.
-    /// @param _newAssetPool New asset pool
-    function approveNewAssetPoolUpgrade(IAssetPoolUpgrade _newAssetPool)
-        external
-        onlyOwner
-    {
-        assetPool.approveNewAssetPoolUpgrade(_newAssetPool);
     }
 
     /// @notice Returns the time remaining until the risk manager approval
@@ -231,6 +216,21 @@ contract CoveragePool is Ownable {
                 CoveragePoolConstants.RISK_MANAGER_GOVERNANCE_DELAY,
                 "Risk manager unapproval not initiated"
             );
+    }
+
+    /// @notice Calculates amount of tokens to be seized from the coverage pool.
+    /// @param portionToSeize Portion of the pool to seize in the range (0, 1]
+    ///        multiplied by FLOATING_POINT_DIVISOR.
+    function amountToSeize(uint256 portionToSeize)
+        public
+        view
+        returns (uint256)
+    {
+        return
+            collateralToken
+                .balanceOf(address(assetPool))
+                .mul(portionToSeize)
+                .div(CoveragePoolConstants.FLOATING_POINT_DIVISOR);
     }
 
     /// @notice Get the time remaining until the function parameter timer

--- a/contracts/SignerBondsUniswapV2.sol
+++ b/contracts/SignerBondsUniswapV2.sol
@@ -39,6 +39,7 @@ interface IUniswapV2Router {
 
     function factory() external pure returns (address);
 
+    /* solhint-disable-next-line func-name-mixedcase */
     function WETH() external pure returns (address);
 }
 

--- a/contracts/SignerBondsUniswapV2.sol
+++ b/contracts/SignerBondsUniswapV2.sol
@@ -25,10 +25,6 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 ///      router contract. For more info and function description please see:
 ///      https://uniswap.org/docs/v2/smart-contracts/router02
 interface IUniswapV2Router {
-    function factory() external pure returns (address);
-
-    function WETH() external pure returns (address);
-
     function swapExactETHForTokens(
         uint256 amountOutMin,
         address[] calldata path,
@@ -40,6 +36,10 @@ interface IUniswapV2Router {
         external
         view
         returns (uint256[] memory amounts);
+
+    function factory() external pure returns (address);
+
+    function WETH() external pure returns (address);
 }
 
 /// @notice Interface for the Uniswap v2 pair.

--- a/contracts/test/AuctionStub.sol
+++ b/contracts/test/AuctionStub.sol
@@ -5,11 +5,11 @@ pragma solidity <0.9.0;
 import "../interfaces/IAuction.sol";
 
 contract AuctionStub is IAuction {
-    event TakeOffer(uint256 amount);
-
     uint256 public divisor;
     uint256 public offer;
     uint256 public amountOutstanding;
+
+    event TakeOffer(uint256 amount);
 
     /// @dev Simulates calling Auction.takeOffer(amount) from the
     ///      AuctionBidder contract.

--- a/contracts/test/DepositStub.sol
+++ b/contracts/test/DepositStub.sol
@@ -75,15 +75,14 @@ contract DepositStub is IDeposit {
         currentState = uint256(States.LIQUIDATION_IN_PROGRESS);
     }
 
-    function withdrawableAmount() external view override returns (uint256) {
-        return address(this).balance;
-    }
-
-    //
-    // Not in tBTC deposit interface, functions below were added just for tests.
-    //
-
+    ///
+    /// Not in tBTC deposit interface, added just for tests.
+    ///
     function setAuctionValue(uint256 _auctionValue) external {
         auctionValue = _auctionValue;
+    }
+
+    function withdrawableAmount() external view override returns (uint256) {
+        return address(this).balance;
     }
 }

--- a/contracts/test/UniswapV2RouterStub.sol
+++ b/contracts/test/UniswapV2RouterStub.sol
@@ -62,6 +62,7 @@ contract UniswapV2RouterStub is IUniswapV2Router {
     }
 
     /// @dev Returns mainnet address in order to get verifiable pair addresses.
+    /* solhint-disable-next-line func-name-mixedcase */
     function WETH() external pure override returns (address) {
         return 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
     }

--- a/contracts/test/UniswapV2RouterStub.sol
+++ b/contracts/test/UniswapV2RouterStub.sol
@@ -18,16 +18,6 @@ contract UniswapV2RouterStub is IUniswapV2Router {
         uint256 deadline
     );
 
-    /// @dev Returns mainnet address in order to get verifiable pair addresses.
-    function factory() external pure override returns (address) {
-        return 0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f;
-    }
-
-    /// @dev Returns mainnet address in order to get verifiable pair addresses.
-    function WETH() external pure override returns (address) {
-        return 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
-    }
-
     function setExchangeRate(uint256 _exchangeRate) external {
         exchangeRate = _exchangeRate;
     }
@@ -64,5 +54,15 @@ contract UniswapV2RouterStub is IUniswapV2Router {
         amounts[1] = amountIn.mul(exchangeRate).mul(997).div(1000); // simulate 0.3% fee
 
         return amounts;
+    }
+
+    /// @dev Returns mainnet address in order to get verifiable pair addresses.
+    function factory() external pure override returns (address) {
+        return 0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f;
+    }
+
+    /// @dev Returns mainnet address in order to get verifiable pair addresses.
+    function WETH() external pure override returns (address) {
+        return 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
     }
 }


### PR DESCRIPTION
Small linter cleanup to eliminate warnings from linter that are especially annoying when rendered in the PR changeset while no files were touched by the PR.