### PR TITLE
Allow auctions for fraud liquidations

### DIFF
--- a/contracts/RiskManagerV1.sol
+++ b/contracts/RiskManagerV1.sol
@@ -417,7 +417,7 @@ contract RiskManagerV1 is IRiskManager, Auctioneer, Ownable {
         IDeposit deposit = IDeposit(auctionToDeposit[address(auction)]);
         // Make sure the deposit was not liquidated outside of Coverage Pool
         require(
-            deposit.currentState() == DEPOSIT_LIQUIDATION_IN_PROGRESS_STATE,
+            isDepositLiquidationInProgress(deposit),
             "Deposit liquidation is not in progress"
         );
 

--- a/contracts/RiskManagerV1.sol
+++ b/contracts/RiskManagerV1.sol
@@ -70,6 +70,7 @@ contract RiskManagerV1 is IRiskManager, Auctioneer, Ownable {
 
     uint256 public constant GOVERNANCE_TIME_DELAY = 12 hours;
 
+    uint256 public constant DEPOSIT_FRAUD_LIQUIDATION_IN_PROGRESS_STATE = 9;
     uint256 public constant DEPOSIT_LIQUIDATION_IN_PROGRESS_STATE = 10;
     uint256 public constant DEPOSIT_LIQUIDATED_STATE = 11;
     // Coverage pool auction will not be opened if the deposit's bond auction
@@ -176,7 +177,7 @@ contract RiskManagerV1 is IRiskManager, Auctioneer, Ownable {
 
         IDeposit deposit = IDeposit(depositAddress);
         require(
-            deposit.currentState() == DEPOSIT_LIQUIDATION_IN_PROGRESS_STATE,
+            isDepositLiquidationInProgress(deposit),
             "Deposit is not in liquidation state"
         );
 
@@ -454,7 +455,7 @@ contract RiskManagerV1 is IRiskManager, Auctioneer, Ownable {
         IDeposit deposit = IDeposit(auctionToDeposit[address(auction)]);
         // Make sure the deposit was not liquidated outside of Coverage Pool
         require(
-            deposit.currentState() == DEPOSIT_LIQUIDATION_IN_PROGRESS_STATE,
+            isDepositLiquidationInProgress(deposit),
             "Deposit liquidation is not in progress"
         );
     }
@@ -477,5 +478,16 @@ contract RiskManagerV1 is IRiskManager, Auctioneer, Ownable {
         } else {
             return delay.sub(elapsed);
         }
+    }
+
+    function isDepositLiquidationInProgress(IDeposit deposit)
+        internal
+        view
+        returns (bool)
+    {
+        uint256 state = deposit.currentState();
+
+        return (state == DEPOSIT_LIQUIDATION_IN_PROGRESS_STATE ||
+            state == DEPOSIT_FRAUD_LIQUIDATION_IN_PROGRESS_STATE);
     }
 }

--- a/contracts/test/DepositStub.sol
+++ b/contracts/test/DepositStub.sol
@@ -86,4 +86,8 @@ contract DepositStub is IDeposit {
     function setAuctionValue(uint256 _auctionValue) external {
         auctionValue = _auctionValue;
     }
+
+    function notifyFraud() external {
+        currentState = uint256(States.FRAUD_LIQUIDATION_IN_PROGRESS);
+    }
 }

--- a/contracts/test/DepositStub.sol
+++ b/contracts/test/DepositStub.sol
@@ -82,11 +82,14 @@ contract DepositStub is IDeposit {
         auctionValue = _auctionValue;
     }
 
-    function withdrawableAmount() external view override returns (uint256) {
-        return address(this).balance;
-    }
-
+    ///
+    /// Not in tBTC deposit interface, added just for tests.
+    ///
     function notifyFraud() external {
         currentState = uint256(States.FRAUD_LIQUIDATION_IN_PROGRESS);
+    }
+
+    function withdrawableAmount() external view override returns (uint256) {
+        return address(this).balance;
     }
 }

--- a/test/RiskManagerV1.test.js
+++ b/test/RiskManagerV1.test.js
@@ -297,6 +297,17 @@ describe("RiskManagerV1", () => {
           )
         })
       })
+
+      context("when deposit is in liquidation state due to fraud", () => {
+        it("should not revert", async () => {
+          await mockTbtcDepositToken.mock.exists.returns(true)
+          await depositStub.notifyFraud()
+          await depositStub.setAuctionValue(bondedAmount)
+
+          await expect(riskManagerV1.notifyLiquidation(depositStub.address)).to
+            .not.be.reverted
+        })
+      })
     })
   })
 


### PR DESCRIPTION
Closes: https://github.com/keep-network/coverage-pools/issues/99

The risk manager should accept all deposits which are in liquidation due to fraud.