### PR TITLE
[System test] Modify test for happy liquidation path - add collateral tokens to the asset pool

### DIFF
--- a/test/system/constants.js
+++ b/test/system/constants.js
@@ -4,6 +4,7 @@ module.exports.tbtcDepositTokenAddress =
   "0x10b66bd1e3b5a936b7f8dbc5976004311037cdf0"
 // https://allthekeeps.com/deposit/0x55d8b1dd88e60d12c81b5479186c15d07555db9d)
 module.exports.depositAddress = "0x55d8b1dd88e60d12c81b5479186c15d07555db9d"
+module.exports.underwriterAddress = "0x5203aeaaee721195707b01e613b6c3259b3a5cf6"
 module.exports.bidderAddress = "0xa0216ED2202459068a750bDf74063f677613DA34"
 module.exports.thirdPartyAddress = "0xa0216ED2202459068a750bDf74063f677613DA34"
 module.exports.uniswapV2RouterAddress =

--- a/test/system/liquidation.test.js
+++ b/test/system/liquidation.test.js
@@ -12,7 +12,7 @@ const { initContracts } = require("./init-contracts")
 const { underwriterAddress, bidderAddress1 } = require("./constants.js")
 
 const Auction = require("../../artifacts/contracts/Auction.sol/Auction.json")
-const precision = to1ePrecision(1, 15) // 0.001 precision
+const precision = to1ePrecision(1, 16) // 0.01 precision
 const describeFn =
   process.env.NODE_ENV === "system-test" ? describe : describe.skip
 
@@ -157,20 +157,20 @@ describeFn("System -- liquidation", () => {
 
     it("should transfer collateral tokens to the bidder", async () => {
       expect(await collateralToken.balanceOf(bidder.address)).to.be.closeTo(
-        to1e18(6),
+        to1e18(6), // 30% of the initial asset pool
         precision
       )
       expect(await collateralToken.balanceOf(assetPool.address)).to.be.closeTo(
-        to1e18(14),
+        to1e18(14), // 70% of the initial asset pool
         precision
       )
     })
 
     it("should consume a reasonable amount of gas", async () => {
-      await expect(parseInt(tx.gasLimit)).to.be.lessThan(500000)
+      await expect(parseInt(tx.gasLimit)).to.be.lessThan(516000)
 
       const txReceipt = await ethers.provider.getTransactionReceipt(tx.hash)
-      await expect(parseInt(txReceipt.gasUsed)).to.be.lessThan(243000)
+      await expect(parseInt(txReceipt.gasUsed)).to.be.lessThan(255000)
     })
   })
 })

--- a/test/system/liquidation.test.js
+++ b/test/system/liquidation.test.js
@@ -128,7 +128,7 @@ describeFn("System -- liquidation", () => {
       await assetPool.connect(underwriter).deposit(collateralAmount)
 
       // Wait 30% of the auction length and take offer
-      await increaseTime((await riskManagerV1.auctionLength()) * 0.3)
+      await increaseTime(25920)
       tx = await auction.takeOffer(lotSize)
     })
 
@@ -144,18 +144,15 @@ describeFn("System -- liquidation", () => {
       // Deposit has been liquidated.
       expect(await tbtcDeposit1.currentState()).to.equal(11) // LIQUIDATED
 
-      // The percentage of signer bonds that should land on the risk manager
-      // contract consists of:
-      // * the initial 66%
-      // * portion of the remaining 34% depending on how much auction length
-      //   passed since notified liquidation and offer taken:
-      // The percentage is therefore equal to:
-      // (66 + 34 * ((25920 + 22870)/86400)) = 85.1997685185
-      const expectedBondsAmount = bondedAmount
-        .mul(851997685185)
-        .div(1000000000000)
-
-        await expect(tx).to.changeEtherBalance(riskManagerV1, expectedBondsAmount)
+      // The percentage of signer bonds that should be sent to the risk manager
+      // contract consists of the initial 66% and a portion of the remaining 34%
+      // that depends on the time passed before take offer. The percentage
+      // (rounded to the whole number) is therefore equal to:
+      // (66 + 34 * ((25920 + 22870)/86400)) = 85
+      await expect(tx).to.changeEtherBalance(
+        riskManagerV1,
+        bondedAmount.mul(85).div(100)
+      )
     })
 
     it("should transfer collateral tokens to the bidder", async () => {


### PR DESCRIPTION
This pull request modifies the happy path liquidation system test to check if collateral tokens from the asset pool will be seized in the correct proportion.
After this pull request is merged, the system test will have all the assertions listed in point 1 of [this table](https://github.com/keep-network/coverage-pools/issues/83#issuecomment-860604097).