### PR TITLE
Increased withdrawal delay to 21 days

### DIFF
--- a/contracts/AssetPool.sol
+++ b/contracts/AssetPool.sol
@@ -47,7 +47,7 @@ contract AssetPool is Ownable, IAssetPool {
     // initiating and completing the withdrawal. During that time, underwriter
     // is still earning rewards and their share of the pool is still a subject
     // of a possible coverage claim.
-    uint256 public withdrawalDelay = 14 days;
+    uint256 public withdrawalDelay = 21 days;
     uint256 public newWithdrawalDelay;
     uint256 public withdrawalDelayChangeInitiated;
     // The time the underwriter has after the withdrawal delay passed to

--- a/test/AssetPool.test.js
+++ b/test/AssetPool.test.js
@@ -513,7 +513,7 @@ describe("AssetPool", () => {
           .approve(assetPool.address, amount)
         await assetPool.connect(underwriter1).initiateWithdrawal(amount)
 
-        await increaseTime(14 * 86400 - 1) // 14 days - 1 sec
+        await increaseTime(21 * 86400 - 1) // 21 days - 1 sec
       })
 
       it("should revert", async () => {
@@ -533,7 +533,7 @@ describe("AssetPool", () => {
           .connect(underwriter1)
           .approve(assetPool.address, amount)
         await assetPool.connect(underwriter1).initiateWithdrawal(amount)
-        await increaseTime((14 + 2) * 86400) // 14 + 2 days
+        await increaseTime((21 + 2) * 86400) // 21 + 2 days
       })
 
       it("should revert", async () => {
@@ -554,7 +554,7 @@ describe("AssetPool", () => {
           .connect(underwriter1)
           .approve(assetPool.address, amount)
         await assetPool.connect(underwriter1).initiateWithdrawal(amount)
-        await increaseTime(14 * 86400) // 14 days
+        await increaseTime(21 * 86400) // 21 days
         const tx = await assetPool.completeWithdrawal(underwriter1.address)
 
         expect(tx)
@@ -603,7 +603,7 @@ describe("AssetPool", () => {
             .connect(underwriter4)
             .initiateWithdrawal(depositedUnderwriter4)
 
-          await increaseTime(14 * 86400) // 14 days
+          await increaseTime(21 * 86400) // 21 days
         })
 
         it("should let all underwriters withdraw their original collateral amounts", async () => {
@@ -670,7 +670,7 @@ describe("AssetPool", () => {
             .connect(underwriter3)
             .initiateWithdrawal(coverageMintedUnderwriter3)
 
-          await increaseTime(14 * 86400) // 14 days
+          await increaseTime(21 * 86400) // 21 days
           await assetPool.completeWithdrawal(underwriter1.address)
           await assetPool.completeWithdrawal(underwriter2.address)
           await assetPool.completeWithdrawal(underwriter3.address)
@@ -756,7 +756,7 @@ describe("AssetPool", () => {
             .connect(underwriter3)
             .initiateWithdrawal(coverageMintedUnderwriter3)
 
-          await increaseTime(14 * 86400) // 14 days
+          await increaseTime(21 * 86400) // 21 days
           await assetPool.completeWithdrawal(underwriter1.address)
           await assetPool.completeWithdrawal(underwriter2.address)
           await assetPool.completeWithdrawal(underwriter3.address)
@@ -867,7 +867,7 @@ describe("AssetPool", () => {
               .connect(underwriter3)
               .initiateWithdrawal(coverageMintedUnderwriter3)
 
-            await increaseTime(14 * 86400) // 14 days
+            await increaseTime(21 * 86400) // 21 days
             await assetPool.completeWithdrawal(underwriter1.address)
             await assetPool.completeWithdrawal(underwriter2.address)
             await assetPool.completeWithdrawal(underwriter3.address)
@@ -1191,18 +1191,18 @@ describe("AssetPool", () => {
       })
 
       it("should not update withdrawal delay", async () => {
-        // 1209600 sec = 14 days, default value
-        expect(await assetPool.withdrawalDelay()).to.equal(1209600)
+        // 1814400 sec = 21 days, default value
+        expect(await assetPool.withdrawalDelay()).to.equal(1814400)
       })
 
       it("should start the governance delay timer", async () => {
-        // 14 days (withdrawal delay) +
+        // 21 days (withdrawal delay) +
         // 2 days (withdrawal timeout) +
         // 2 days additional delay
         expect(
           await assetPool.getRemainingWithdrawalDelayUpdateTime()
         ).to.equal(
-          1555200 // 18 days
+          2160000 // 25 days
         )
       })
 
@@ -1318,13 +1318,13 @@ describe("AssetPool", () => {
       })
 
       it("should start the governance delay timer", async () => {
-        // 14 days (withdrawal delay) +
+        // 21 days (withdrawal delay) +
         // 2 days (withdrawal timeout) +
         // 2 days additional delay
         expect(
           await assetPool.getRemainingWithdrawalTimeoutUpdateTime()
         ).to.equal(
-          1555200 // 18 days
+          2160000 // 25 days
         )
       })
 


### PR DESCRIPTION
Closes #89 

We were looking at historical liquidations and 14 days withdrawal delay
could not be enough in all cases. Of course, those are just historical
data and there is no guarantee future will look similar but if something
already happened there is a chance it will happen again and we should be
prepared.

All liquidations we had on mainnet can be reduced to three cases:
- liquidations around ~Nov 5th,
- liquidations around ~Nov 17th,
- liquidations around ~Dec 26th.

If I were coverage pool underwriter having a strategy to withdraw all my
funds when it starts getting risky setting the threshold at 135%
collateralization level, two week withdrawal period would not stop me
from escaping the pool for Nov 17th liquidation. We can not stop people
from withdrawing but the whole point of a coverage pool is to be with
the pool when it is sunny outside, everyone is happy, and earning
rewards, and be with the pool when the storm is coming so that there is
that last-chance insurance. We do not want to make it easy for
underwriters trying to escape when they see a small cloud on the sky
and being interested in a free ride on everyone else's shoulders. 21 days
withdrawal delay feels like a good tradeoff.

![aaa1](https://user-images.githubusercontent.com/4712360/123096015-f3468000-d42e-11eb-8126-4a3672688f35.png)

![aaa2](https://user-images.githubusercontent.com/4712360/123096032-f7729d80-d42e-11eb-9551-7f43023d4a94.png)

![aaa3](https://user-images.githubusercontent.com/4712360/123096046-fa6d8e00-d42e-11eb-8c44-7e5ac4328981.png)

