### PR TITLE
Immutable fields

### DIFF
--- a/contracts/AssetPool.sol
+++ b/contracts/AssetPool.sol
@@ -121,8 +121,7 @@ contract AssetPool is Ownable, IAssetPool {
         collateralToken = _collateralToken;
         underwriterToken = _underwriterToken;
 
-        rewardsPool = new RewardsPool(_collateralToken, this);
-        rewardsPool.transferOwnership(rewardsManager);
+        rewardsPool = new RewardsPool(_collateralToken, this, rewardsManager);
     }
 
     /// @notice Accepts the given amount of collateral token as a deposit and

--- a/contracts/AssetPool.sol
+++ b/contracts/AssetPool.sol
@@ -35,10 +35,10 @@ contract AssetPool is Ownable, IAssetPool {
     using SafeERC20 for IERC20;
     using SafeERC20 for UnderwriterToken;
 
-    IERC20 public collateralToken;
-    UnderwriterToken public underwriterToken;
+    IERC20 public immutable collateralToken;
+    UnderwriterToken public immutable underwriterToken;
 
-    RewardsPool public rewardsPool;
+    RewardsPool public immutable rewardsPool;
 
     IAssetPoolUpgrade public newAssetPool;
 

--- a/contracts/AuctionBidder.sol
+++ b/contracts/AuctionBidder.sol
@@ -22,7 +22,7 @@ import "./CoveragePool.sol";
 ///         contract offers additional features for bidders to decide if their
 ///         requirements for making a purchase are satisfied.
 contract AuctionBidder {
-    CoveragePool public coveragePool;
+    CoveragePool public immutable coveragePool;
 
     constructor(CoveragePool _coveragePool) {
         coveragePool = _coveragePool;

--- a/contracts/Auctioneer.sol
+++ b/contracts/Auctioneer.sol
@@ -28,11 +28,11 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 contract Auctioneer is CloneFactory {
     // Holds the address of the auction contract
     // which will be used as a master contract for cloning.
-    address public masterAuction;
+    address public immutable masterAuction;
     mapping(address => bool) public openAuctions;
     uint256 public openAuctionsCount;
 
-    CoveragePool public coveragePool;
+    CoveragePool public immutable coveragePool;
 
     event AuctionCreated(
         address indexed tokenAccepted,
@@ -49,8 +49,6 @@ contract Auctioneer is CloneFactory {
     event AuctionClosed(address indexed auction);
 
     constructor(CoveragePool _coveragePool, address _masterAuction) {
-        require(_masterAuction != address(0), "Invalid master auction address");
-        require(masterAuction == address(0), "Auctioneer already initialized");
         coveragePool = _coveragePool;
         masterAuction = _masterAuction;
     }

--- a/contracts/Auctioneer.sol
+++ b/contracts/Auctioneer.sol
@@ -50,6 +50,7 @@ contract Auctioneer is CloneFactory {
 
     constructor(CoveragePool _coveragePool, address _masterAuction) {
         coveragePool = _coveragePool;
+        // slither-disable-next-line missing-zero-check
         masterAuction = _masterAuction;
     }
 

--- a/contracts/CoveragePool.sol
+++ b/contracts/CoveragePool.sol
@@ -219,19 +219,6 @@ contract CoveragePool is Ownable {
             );
     }
 
-    /// @notice Calculates amount of tokens to be seized from the coverage pool.
-    /// @param portionToSeize Portion of the pool to seize in the range (0, 1]
-    ///        multiplied by FLOATING_POINT_DIVISOR.
-    function amountToSeize(uint256 portionToSeize)
-        public
-        view
-        returns (uint256)
-    {
-        return
-            (collateralToken.balanceOf(address(assetPool)) * portionToSeize) /
-            CoveragePoolConstants.FLOATING_POINT_DIVISOR;
-    }
-
     /// @notice Calculates the amount of COV tokens for a grant. COV tokens are
     ///         granted as reward for the notifier reporting about deposit
     ///         liquidation start or deposit being liquidated outside of the
@@ -250,6 +237,19 @@ contract CoveragePool is Ownable {
 
         return
             (portionToGrant * covTotalSupply) /
+            CoveragePoolConstants.FLOATING_POINT_DIVISOR;
+    }
+
+    /// @notice Calculates amount of tokens to be seized from the coverage pool.
+    /// @param portionToSeize Portion of the pool to seize in the range (0, 1]
+    ///        multiplied by FLOATING_POINT_DIVISOR.
+    function amountToSeize(uint256 portionToSeize)
+        public
+        view
+        returns (uint256)
+    {
+        return
+            (collateralToken.balanceOf(address(assetPool)) * portionToSeize) /
             CoveragePoolConstants.FLOATING_POINT_DIVISOR;
     }
 }

--- a/contracts/CoveragePool.sol
+++ b/contracts/CoveragePool.sol
@@ -30,8 +30,8 @@ import "./interfaces/IAssetPoolUpgrade.sol";
 /// @dev Coverage pool contract is owned by the governance. Coverage pool is the
 ///      owner of the asset pool contract.
 contract CoveragePool is Ownable {
-    AssetPool public assetPool;
-    IERC20 public collateralToken;
+    AssetPool public immutable assetPool;
+    IERC20 public immutable collateralToken;
 
     bool public firstRiskManagerApproved = false;
 

--- a/contracts/RewardsPool.sol
+++ b/contracts/RewardsPool.sol
@@ -48,9 +48,14 @@ contract RewardsPool is Ownable {
     event RewardToppedUp(uint256 amount);
     event RewardWithdrawn(uint256 amount);
 
-    constructor(IERC20 _rewardToken, AssetPool _assetPool) {
+    constructor(
+        IERC20 _rewardToken,
+        AssetPool _assetPool,
+        address owner
+    ) {
         rewardToken = _rewardToken;
         assetPool = address(_assetPool);
+        transferOwnership(owner);
     }
 
     /// @notice Transfers the provided reward amount into RewardsPool and

--- a/contracts/RewardsPool.sol
+++ b/contracts/RewardsPool.sol
@@ -31,8 +31,8 @@ contract RewardsPool is Ownable {
 
     uint256 public constant DURATION = 7 days;
 
-    IERC20 public rewardToken;
-    address public assetPool;
+    IERC20 public immutable rewardToken;
+    address public immutable assetPool;
 
     // timestamp of the current reward interval end or the timestamp of the
     // last interval end in case a new reward interval has not been allocated

--- a/contracts/RiskManagerV1.sol
+++ b/contracts/RiskManagerV1.sol
@@ -88,8 +88,8 @@ contract RiskManagerV1 is IRiskManager, Auctioneer, Ownable {
     uint256 public newAuctionLength;
     uint256 public auctionLengthChangeInitiated;
 
-    IERC20 public tbtcToken;
-    ITBTCDepositToken public tbtcDepositToken;
+    IERC20 public immutable tbtcToken;
+    ITBTCDepositToken public immutable tbtcDepositToken;
     // tBTC surplus collected from early closed auctions.
     uint256 public tbtcSurplus;
 

--- a/contracts/RiskManagerV1.sol
+++ b/contracts/RiskManagerV1.sol
@@ -759,6 +759,7 @@ contract RiskManagerV1 is IRiskManager, Auctioneer, Ownable {
 ///         All parameters can be updated using a two-phase process.
 /// @dev The client contract should take care of authorizations or governance
 ///      delays according to their needs.
+/* solhint-disable-next-line ordering */
 library RiskManagerV1Rewards {
     struct Storage {
         // Fixed amount of COV tokens which should be given as reward for the

--- a/contracts/SignerBondsUniswapV2.sol
+++ b/contracts/SignerBondsUniswapV2.sol
@@ -71,10 +71,10 @@ contract SignerBondsUniswapV2 is ISignerBondsSwapStrategy, Ownable {
     // One basis point is equivalent to 1/100th of a percent.
     uint256 public constant BASIS_POINTS_DIVISOR = 10000;
 
-    IUniswapV2Router public uniswapRouter;
-    IUniswapV2Pair public uniswapPair;
-    address public assetPool;
-    address public collateralToken;
+    IUniswapV2Router public immutable uniswapRouter;
+    IUniswapV2Pair public immutable uniswapPair;
+    address public immutable assetPool;
+    address public immutable collateralToken;
 
     // Determines the maximum allowed price impact for the swap transaction.
     // If transaction's price impact is higher, transaction will be reverted.
@@ -97,12 +97,13 @@ contract SignerBondsUniswapV2 is ISignerBondsSwapStrategy, Ownable {
     constructor(IUniswapV2Router _uniswapRouter, CoveragePool _coveragePool) {
         uniswapRouter = _uniswapRouter;
         assetPool = address(_coveragePool.assetPool());
-        collateralToken = address(_coveragePool.collateralToken());
+        address _collateralToken = address(_coveragePool.collateralToken());
+        collateralToken = _collateralToken;
         uniswapPair = IUniswapV2Pair(
             computePairAddress(
                 _uniswapRouter.factory(),
                 _uniswapRouter.WETH(),
-                collateralToken
+                _collateralToken
             )
         );
     }

--- a/contracts/test/SignerBondsUniswapV2Stub.sol
+++ b/contracts/test/SignerBondsUniswapV2Stub.sol
@@ -8,10 +8,4 @@ contract SignerBondsUniswapV2Stub is SignerBondsUniswapV2 {
     constructor(IUniswapV2Router _uniswapRouter, CoveragePool _coveragePool)
         SignerBondsUniswapV2(_uniswapRouter, _coveragePool)
     {}
-
-    /// @dev Meant to be used in tests where there is no possibility to
-    ///      deploy the pair contract at a deterministic address.
-    function setUniswapPair(IUniswapV2Pair _uniswapPair) external {
-        uniswapPair = _uniswapPair;
-    }
 }

--- a/contracts/test/UniswapV2RouterStub.sol
+++ b/contracts/test/UniswapV2RouterStub.sol
@@ -42,11 +42,12 @@ contract UniswapV2RouterStub is IUniswapV2Router {
 
     /// @dev Always assumes there are two elements in the path and
     ///      WETH is the first one.
-    function getAmountsOut(
-        uint256 amountIn,
-        /* solhint-disable-next-line no-unused-vars */
-        address[] calldata path
-    ) external view override returns (uint256[] memory amounts) {
+    function getAmountsOut(uint256 amountIn, address[] calldata)
+        external
+        view
+        override
+        returns (uint256[] memory amounts)
+    {
         amounts = new uint256[](2);
         amounts[0] = amountIn;
         amounts[1] = (amountIn * exchangeRate * 997) / 1000; // simulate 0.3% fee

--- a/test/RewardsPool.test.js
+++ b/test/RewardsPool.test.js
@@ -26,9 +26,12 @@ describe("RewardsPool", () => {
     await rewardToken.deployed()
 
     const RewardsPool = await ethers.getContractFactory("RewardsPool")
-    pool = await RewardsPool.deploy(rewardToken.address, assetPool.address)
+    pool = await RewardsPool.deploy(
+      rewardToken.address,
+      assetPool.address,
+      rewardManager.address
+    )
     await pool.deployed()
-    await pool.transferOwnership(rewardManager.address)
 
     await rewardToken.mint(rewardManager.address, to1e18(500000))
     await rewardToken.mint(thirdParty.address, to1e18(500000))


### PR DESCRIPTION
Closes #122 

Marked all fields that could be marked as `immutable` as such. This gives some gas savings, for example (avg, from unit tests):
- `AssetPool.deposit`: 137334 -> 126382
- `Auction.takeOffer`: 98681 -> 96972
- `RiskManager.notifyLiquidation`: 268884 -> 261182

I have also taken the opportunity and cleaned up last three linter issues in https://github.com/keep-network/coverage-pools/pull/123/commits/6f149da949f59669351fe721e776032b775c1227.