### PR TITLE
notifyRedemptionSignatureTimedOut extracted out of IDeposit

### DIFF
--- a/contracts/RiskManagerV1.sol
+++ b/contracts/RiskManagerV1.sol
@@ -25,15 +25,14 @@ import "./interfaces/IRiskManager.sol";
 
 /// @notice tBTC v1 Deposit contract interface.
 /// @dev This is an interface with just a few function signatures of a main
-///      contract from tBTC. For more info and function description
-///      please see:
+///      Deposit contract from tBTC. tBTC deposit contract functions declared in
+///      this interface are used by RiskManagerV1 contract to interact with tBTC
+///      v1 deposits. For more information about tBTC Deposit please see:
 ///      https://github.com/keep-network/tbtc/blob/solidity/v1.1.0/solidity/contracts/deposit/Deposit.sol
 interface IDeposit {
     function withdrawFunds() external;
 
     function purchaseSignerBondsAtAuction() external;
-
-    function notifyRedemptionSignatureTimedOut() external;
 
     function currentState() external view returns (uint256);
 
@@ -46,8 +45,7 @@ interface IDeposit {
 
 /// @notice tBTC v1 deposit token interface.
 /// @dev This is an interface with just a few function signatures of a main
-///      contract from tBTC. For more info and function description
-///      please see:
+///      contract from tBTC. For more information about tBTC Deposit please see:
 ///      https://github.com/keep-network/tbtc/blob/solidity/v1.1.0/solidity/contracts/system/TBTCDepositToken.sol
 interface ITBTCDepositToken {
     function exists(uint256 _tokenId) external view returns (bool);

--- a/contracts/test/DepositStub.sol
+++ b/contracts/test/DepositStub.sol
@@ -6,7 +6,7 @@ import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 import "../RiskManagerV1.sol";
 
-/// @dev tBTC v1 deposit interace with a subset of functions used by unit and
+/// @dev tBTC v1 deposit interface with a subset of functions used by unit and
 ///      system tests. For more information about tBTC Deposit, please see:
 ///      https://github.com/keep-network/tbtc/blob/solidity/v1.1.0/solidity/contracts/deposit/Deposit.sol
 interface ITBTCDeposit is IDeposit {
@@ -16,7 +16,7 @@ interface ITBTCDeposit is IDeposit {
 /// @dev Stub contract simulating - in a simplified way - behavior of tBTC v1
 ///      deposit when it comes to purchasing signer bonds. This is _not_
 ///      a complete tBTC v1 Deposit implementation.
-contract DepositStub is IDeposit {
+contract DepositStub is ITBTCDeposit {
     using SafeERC20 for IERC20;
 
     enum States {
@@ -78,7 +78,7 @@ contract DepositStub is IDeposit {
         currentState = uint256(States.LIQUIDATION_IN_PROGRESS);
     }
 
-    function notifyRedemptionSignatureTimedOut() external {
+    function notifyRedemptionSignatureTimedOut() external override {
         currentState = uint256(States.LIQUIDATION_IN_PROGRESS);
     }
 

--- a/contracts/test/DepositStub.sol
+++ b/contracts/test/DepositStub.sol
@@ -6,6 +6,13 @@ import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 import "../RiskManagerV1.sol";
 
+/// @dev tBTC v1 deposit interace with a subset of functions used by unit and
+///      system tests. For more information about tBTC Deposit, please see:
+///      https://github.com/keep-network/tbtc/blob/solidity/v1.1.0/solidity/contracts/deposit/Deposit.sol
+interface ITBTCDeposit is IDeposit {
+    function notifyRedemptionSignatureTimedOut() external;
+}
+
 /// @dev Stub contract simulating - in a simplified way - behavior of tBTC v1
 ///      deposit when it comes to purchasing signer bonds. This is _not_
 ///      a complete tBTC v1 Deposit implementation.
@@ -71,7 +78,7 @@ contract DepositStub is IDeposit {
         currentState = uint256(States.LIQUIDATION_IN_PROGRESS);
     }
 
-    function notifyRedemptionSignatureTimedOut() external override {
+    function notifyRedemptionSignatureTimedOut() external {
         currentState = uint256(States.LIQUIDATION_IN_PROGRESS);
     }
 

--- a/test/system/init-contracts.js
+++ b/test/system/init-contracts.js
@@ -42,9 +42,18 @@ async function initContracts(swapStrategy) {
     "IUniswapV2Router",
     uniswapV2RouterAddress
   )
-  const tbtcDeposit1 = await ethers.getContractAt("IDeposit", depositAddress1)
-  const tbtcDeposit2 = await ethers.getContractAt("IDeposit", depositAddress2)
-  const tbtcDeposit3 = await ethers.getContractAt("IDeposit", depositAddress3)
+  const tbtcDeposit1 = await ethers.getContractAt(
+    "ITBTCDeposit",
+    depositAddress1
+  )
+  const tbtcDeposit2 = await ethers.getContractAt(
+    "ITBTCDeposit",
+    depositAddress2
+  )
+  const tbtcDeposit3 = await ethers.getContractAt(
+    "ITBTCDeposit",
+    depositAddress3
+  )
 
   const AssetPool = await ethers.getContractFactory("AssetPool")
   const assetPool = await AssetPool.deploy(


### PR DESCRIPTION
Depends on: #123 

`IDeposit` is declared in `RiskManagerV1.sol `and should contain only a subset
of tBTC Deposit functions that are used by tBTC v1 Risk Manager.

`notifyRedemptionSignatureTimedOut` is never called by tBTC v1 Risk
Manager and is used only by system tests to transition tBTC `Deposit`
contract into liquidation state.

`notifyRedemptionSignatureTimedOut` has been extracted to a separate
interface with a subset of functions used by system and unit tests.