### PR TITLE
Final touches: documentation improvements, minor renames, and import reorgs

### DIFF
--- a/contracts/AssetPool.sol
+++ b/contracts/AssetPool.sol
@@ -97,7 +97,7 @@ contract AssetPool is Ownable, IAssetPool {
     );
     event WithdrawalTimeoutUpdated(uint256 withdrawalTimeout);
 
-    /// @notice Reverts if the withdrawl governance delay has not passed yet or
+    /// @notice Reverts if the withdrawal governance delay has not passed yet or
     ///         if the change was not yet initiated.
     /// @param changeInitiatedTimestamp The timestamp at which the change has
     ///        been initiated
@@ -331,7 +331,7 @@ contract AssetPool is Ownable, IAssetPool {
     }
 
     /// @notice Lets the contract owner to begin an update of withdrawal delay
-    ///         paramter value. Withdrawal delay is the time it takes the
+    ///         parameter value. Withdrawal delay is the time it takes the
     ///         underwriter to withdraw their collateral and rewards from the
     ///         pool. This is the time that needs to pass between initiating and
     ///         completing the withdrawal. The change needs to be finalized with

--- a/contracts/AssetPool.sol
+++ b/contracts/AssetPool.sol
@@ -14,15 +14,15 @@
 
 pragma solidity 0.8.4;
 
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
-
 import "./interfaces/IAssetPool.sol";
 import "./interfaces/IAssetPoolUpgrade.sol";
 import "./RewardsPool.sol";
 import "./UnderwriterToken.sol";
 import "./GovernanceUtils.sol";
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
 
 /// @title Asset Pool
 /// @notice Asset pool is a component of a Coverage Pool. Asset Pool
@@ -43,7 +43,7 @@ contract AssetPool is Ownable, IAssetPool {
     IAssetPoolUpgrade public newAssetPool;
 
     /// @notice The time it takes the underwriter to withdraw their collateral
-    ///         and rewards from the pool. This is the time that needs to pass 
+    ///         and rewards from the pool. This is the time that needs to pass
     ///         betweenin itiating and completing the withdrawal. During that
     ///         time, underwriter is still earning rewards and their share of
     ///         the pool is still a subject of a possible coverage claim.
@@ -51,9 +51,9 @@ contract AssetPool is Ownable, IAssetPool {
     uint256 public newWithdrawalDelay;
     uint256 public withdrawalDelayChangeInitiated;
 
-    /// @notice The time the underwriter has after the withdrawal delay passed 
+    /// @notice The time the underwriter has after the withdrawal delay passed
     ///         to complete the withdrawal. During that time, underwriter is
-    ///         still earning rewards and their share of the pool is still 
+    ///         still earning rewards and their share of the pool is still
     ///         a subject of a possible coverage claim.
     ///         After the withdrawal timeout elapses, tokens stay in the pool
     ///         and the underwriters has to initiate the withdrawal again and

--- a/contracts/AssetPool.sol
+++ b/contracts/AssetPool.sol
@@ -44,7 +44,7 @@ contract AssetPool is Ownable, IAssetPool {
 
     /// @notice The time it takes the underwriter to withdraw their collateral
     ///         and rewards from the pool. This is the time that needs to pass
-    ///         betweenin itiating and completing the withdrawal. During that
+    ///         between initiating and completing the withdrawal. During that
     ///         time, underwriter is still earning rewards and their share of
     ///         the pool is still a subject of a possible coverage claim.
     uint256 public withdrawalDelay = 21 days;
@@ -56,7 +56,7 @@ contract AssetPool is Ownable, IAssetPool {
     ///         still earning rewards and their share of the pool is still
     ///         a subject of a possible coverage claim.
     ///         After the withdrawal timeout elapses, tokens stay in the pool
-    ///         and the underwriters has to initiate the withdrawal again and
+    ///         and the underwriter has to initiate the withdrawal again and
     ///         wait for the full withdrawal delay to complete the withdrawal.
     uint256 public withdrawalTimeout = 2 days;
     uint256 public newWithdrawalTimeout;

--- a/contracts/AssetPool.sol
+++ b/contracts/AssetPool.sol
@@ -24,7 +24,7 @@ import "./RewardsPool.sol";
 import "./UnderwriterToken.sol";
 import "./GovernanceUtils.sol";
 
-/// @title AssetPool
+/// @title Asset Pool
 /// @notice Asset pool is a component of a Coverage Pool. Asset Pool
 ///         accepts a single ERC20 token as collateral, and returns an
 ///         underwriter token. For example, an asset pool might accept deposits
@@ -42,21 +42,22 @@ contract AssetPool is Ownable, IAssetPool {
 
     IAssetPoolUpgrade public newAssetPool;
 
-    // The time it takes the underwriter to withdraw their collateral
-    // and rewards from the pool. This is the time that needs to pass between
-    // initiating and completing the withdrawal. During that time, underwriter
-    // is still earning rewards and their share of the pool is still a subject
-    // of a possible coverage claim.
+    /// @notice The time it takes the underwriter to withdraw their collateral
+    ///         and rewards from the pool. This is the time that needs to pass 
+    ///         betweenin itiating and completing the withdrawal. During that
+    ///         time, underwriter is still earning rewards and their share of
+    ///         the pool is still a subject of a possible coverage claim.
     uint256 public withdrawalDelay = 21 days;
     uint256 public newWithdrawalDelay;
     uint256 public withdrawalDelayChangeInitiated;
-    // The time the underwriter has after the withdrawal delay passed to
-    // complete the withdrawal. During that time, underwriter is still earning
-    // rewards and their share of the pool is still a subject of a possible
-    // coverage claim.
-    // After the withdrawal timeout elapses, tokens stay in the pool
-    // and the underwriters has to initiate the withdrawal again and wait for
-    // the full withdrawal delay to complete the withdrawal.
+
+    /// @notice The time the underwriter has after the withdrawal delay passed 
+    ///         to complete the withdrawal. During that time, underwriter is
+    ///         still earning rewards and their share of the pool is still 
+    ///         a subject of a possible coverage claim.
+    ///         After the withdrawal timeout elapses, tokens stay in the pool
+    ///         and the underwriters has to initiate the withdrawal again and
+    ///         wait for the full withdrawal delay to complete the withdrawal.
     uint256 public withdrawalTimeout = 2 days;
     uint256 public newWithdrawalTimeout;
     uint256 public withdrawalTimeoutChangeInitiated;
@@ -99,7 +100,7 @@ contract AssetPool is Ownable, IAssetPool {
     /// @notice Reverts if the withdrawl governance delay has not passed yet or
     ///         if the change was not yet initiated.
     /// @param changeInitiatedTimestamp The timestamp at which the change has
-    ///        been initiated.
+    ///        been initiated
     modifier onlyAfterWithdrawalGovernanceDelay(
         uint256 changeInitiatedTimestamp
     ) {
@@ -240,14 +241,15 @@ contract AssetPool is Ownable, IAssetPool {
     }
 
     /// @notice Transfers collateral tokens to a new Asset Pool which previously
-    ///         was approved by the governance.
+    ///         was approved by the governance. Upgrade does not have to obey
+    ///         withdrawal delay.
     ///         Old underwriter tokens are burned in favor of new tokens minted
     ///         in a new Asset Pool. New tokens are sent directly to the
     ///         underwriter from a new Asset Pool.
     /// @param covAmount Amount of underwriter tokens used to calculate collateral
-    ///                  tokens which are transferred to a new asset pool.
+    ///                  tokens which are transferred to a new asset pool
     /// @param _newAssetPool New Asset Pool address to check validity with the one
-    ///                      that was approved by the governance.
+    ///                      that was approved by the governance
     function upgradeToNewAssetPool(uint256 covAmount, address _newAssetPool)
         external
     {
@@ -304,7 +306,8 @@ contract AssetPool is Ownable, IAssetPool {
     }
 
     /// @notice Allows governance to set a new asset pool so the underwriters
-    ///         can move their collateral tokens to a new asset pool.
+    ///         can move their collateral tokens to a new asset pool without
+    ///         having to wait for the withdrawal delay.
     function approveNewAssetPoolUpgrade(IAssetPoolUpgrade _newAssetPool)
         external
         onlyOwner
@@ -365,7 +368,7 @@ contract AssetPool is Ownable, IAssetPool {
     ///         complete the withdrawal. The change needs to be finalized with
     ///         a call to finalizeWithdrawalTimeoutUpdate after the required
     ///         governance delay passes.
-    /// @param  _newWithdrawalTimeout The new value of the withdrawal timeout.
+    /// @param  _newWithdrawalTimeout The new value of the withdrawal timeout
     function beginWithdrawalTimeoutUpdate(uint256 _newWithdrawalTimeout)
         external
         onlyOwner
@@ -399,8 +402,8 @@ contract AssetPool is Ownable, IAssetPool {
     ///         collateral tokens. Shares are usually granted for notifiers
     ///         reporting about various contract state changes.
     /// @dev Can be called only by the contract owner.
-    /// @param recipient Address of the underwriter tokens recipient.
-    /// @param covAmount Amount of the underwriter tokens which should be minted.
+    /// @param recipient Address of the underwriter tokens recipient
+    /// @param covAmount Amount of the underwriter tokens which should be minted
     function grantShares(address recipient, uint256 covAmount)
         external
         onlyOwner

--- a/contracts/Auction.sol
+++ b/contracts/Auction.sol
@@ -14,9 +14,10 @@
 
 pragma solidity 0.8.4;
 
-import "./Auctioneer.sol";
 import "./interfaces/IAuction.sol";
+import "./Auctioneer.sol";
 import "./CoveragePoolConstants.sol";
+
 import "@openzeppelin/contracts/utils/math/Math.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";

--- a/contracts/Auctioneer.sol
+++ b/contracts/Auctioneer.sol
@@ -17,6 +17,7 @@ pragma solidity 0.8.4;
 import "./CloneFactory.sol";
 import "./Auction.sol";
 import "./CoveragePool.sol";
+
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 /// @title Auctioneer

--- a/contracts/CoveragePool.sol
+++ b/contracts/CoveragePool.sol
@@ -125,7 +125,7 @@ contract CoveragePool is Ownable {
     }
 
     /// @notice Lets the governance to begin an update of withdrawal delay
-    ///         paramter value. Withdrawal delay is the time it takes the
+    ///         parameter value. Withdrawal delay is the time it takes the
     ///         underwriter to withdraw their collateral and rewards from the
     ///         pool. This is the time that needs to pass between initiating and
     ///         completing the withdrawal. The change needs to be finalized with

--- a/contracts/CoveragePool.sol
+++ b/contracts/CoveragePool.sol
@@ -23,7 +23,7 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import "./interfaces/IAssetPoolUpgrade.sol";
 
-/// @title CoveragePool
+/// @title Coverage Pool
 /// @notice A contract that manages a single asset pool. Handles approving and
 ///         unapproving of risk managers and allows them to seize funds from the
 ///         asset pool if they are approved.
@@ -58,7 +58,7 @@ contract CoveragePool is Ownable {
     /// @notice Approves the first risk manager
     /// @dev Can be called only by the contract owner. Can be called only once.
     ///      Does not require any further calls to any functions.
-    /// @param riskManager Risk manager that will be approved.
+    /// @param riskManager Risk manager that will be approved
     function approveFirstRiskManager(address riskManager) external onlyOwner {
         require(
             !firstRiskManagerApproved,
@@ -72,7 +72,7 @@ contract CoveragePool is Ownable {
     /// @dev Can be called only by the contract owner. For a risk manager to be
     ///      approved, a call to `finalizeRiskManagerApproval` must follow
     ///      (after a governance delay).
-    /// @param riskManager Risk manager that will be approved.
+    /// @param riskManager Risk manager that will be approved
     function beginRiskManagerApproval(address riskManager) external onlyOwner {
         /* solhint-disable-next-line not-rely-on-time */
         riskManagerApprovalTimestamps[riskManager] = block.timestamp;
@@ -83,7 +83,7 @@ contract CoveragePool is Ownable {
     /// @notice Finalizes risk manager approval process.
     /// @dev Can be called only by the contract owner. Must be preceded with a
     ///      call to beginRiskManagerApproval and a governance delay must elapse.
-    /// @param riskManager Risk manager that will be approved.
+    /// @param riskManager Risk manager that will be approved
     function finalizeRiskManagerApproval(address riskManager)
         external
         onlyOwner
@@ -106,14 +106,17 @@ contract CoveragePool is Ownable {
 
     /// @notice Unapproves the risk manager. The change takes effect immediately.
     /// @dev Can be called only by the contract owner.
-    /// @param riskManager Risk manager that will be unapproved.
+    /// @param riskManager Risk manager that will be unapproved
     function unapproveRiskManager(address riskManager) external onlyOwner {
         /* solhint-disable-next-line not-rely-on-time */
         emit RiskManagerUnapproved(riskManager, block.timestamp);
         delete approvedRiskManagers[riskManager];
     }
 
-    /// @notice Approves upgradeability of a new asset pool.
+    /// @notice Approves upgradeability to the new asset pool.
+    ///         Allows governance to set a new asset pool so the underwriters
+    ///         can move their collateral tokens to a new asset pool without
+    ///         having to wait for the withdrawal delay.
     /// @param _newAssetPool New asset pool
     function approveNewAssetPoolUpgrade(IAssetPoolUpgrade _newAssetPool)
         external
@@ -151,7 +154,7 @@ contract CoveragePool is Ownable {
     ///         complete the withdrawal. The change needs to be finalized with
     ///         a call to finalizeWithdrawalTimeoutUpdate after the required
     ///         governance delay passes.
-    /// @param  newWithdrawalTimeout The new value of the withdrawal timeout.
+    /// @param  newWithdrawalTimeout The new value of the withdrawal timeout
     function beginWithdrawalTimeoutUpdate(uint256 newWithdrawalTimeout)
         external
         onlyOwner
@@ -172,9 +175,9 @@ contract CoveragePool is Ownable {
     /// @dev `portionToSeize` value was multiplied by `FLOATING_POINT_DIVISOR`
     ///      for calculation precision purposes. Further calculations in this
     ///      function will need to take this divisor into account.
-    /// @param recipient Address that will receive the pool's seized funds.
+    /// @param recipient Address that will receive the pool's seized funds
     /// @param portionToSeize Portion of the pool to seize in the range (0, 1]
-    ///        multiplied by `FLOATING_POINT_DIVISOR`.
+    ///        multiplied by `FLOATING_POINT_DIVISOR`
     function seizeFunds(address recipient, uint256 portionToSeize)
         external
         onlyApprovedRiskManager
@@ -194,8 +197,8 @@ contract CoveragePool is Ownable {
     ///         any collateral tokens. Shares are usually granted for notifiers
     ///         reporting about various contract state changes.
     /// @dev Can be called only by an approved risk manager.
-    /// @param recipient Address of the underwriter tokens recipient.
-    /// @param covAmount Amount of the underwriter tokens which should be minted.
+    /// @param recipient Address of the underwriter tokens recipient
+    /// @param covAmount Amount of the underwriter tokens which should be minted
     function grantAssetPoolShares(address recipient, uint256 covAmount)
         external
         onlyApprovedRiskManager
@@ -242,7 +245,7 @@ contract CoveragePool is Ownable {
 
     /// @notice Calculates amount of tokens to be seized from the coverage pool.
     /// @param portionToSeize Portion of the pool to seize in the range (0, 1]
-    ///        multiplied by FLOATING_POINT_DIVISOR.
+    ///        multiplied by FLOATING_POINT_DIVISOR
     function amountToSeize(uint256 portionToSeize)
         public
         view

--- a/contracts/CoveragePool.sol
+++ b/contracts/CoveragePool.sol
@@ -14,14 +14,13 @@
 
 pragma solidity 0.8.4;
 
+import "./interfaces/IAssetPoolUpgrade.sol";
 import "./AssetPool.sol";
 import "./CoveragePoolConstants.sol";
 import "./GovernanceUtils.sol";
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-
-import "./interfaces/IAssetPoolUpgrade.sol";
 
 /// @title Coverage Pool
 /// @notice A contract that manages a single asset pool. Handles approving and

--- a/contracts/ERC20WithPermit.sol
+++ b/contracts/ERC20WithPermit.sol
@@ -14,9 +14,9 @@
 
 pragma solidity 0.8.4;
 
-import "@openzeppelin/contracts/access/Ownable.sol";
-
 import "./interfaces/IERC20WithPermit.sol";
+
+import "@openzeppelin/contracts/access/Ownable.sol";
 
 /// @title  ERC20WithPermit
 /// @notice Burnable ERC20 token with EIP2612 permit functionality. Users can

--- a/contracts/RewardsPool.sol
+++ b/contracts/RewardsPool.sol
@@ -21,7 +21,7 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 
 import "./AssetPool.sol";
 
-/// @title RewardsPool
+/// @title Rewards Pool
 /// @notice RewardsPool accepts a single reward token and releases it to the
 ///         AssetPool over time in one week reward intervals. The owner of this
 ///         contract is the reward distribution address funding it with reward

--- a/contracts/RewardsPool.sol
+++ b/contracts/RewardsPool.sol
@@ -14,12 +14,12 @@
 
 pragma solidity 0.8.4;
 
+import "./AssetPool.sol";
+
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/utils/math/Math.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
-
-import "./AssetPool.sol";
 
 /// @title Rewards Pool
 /// @notice RewardsPool accepts a single reward token and releases it to the

--- a/contracts/RewardsPool.sol
+++ b/contracts/RewardsPool.sol
@@ -61,7 +61,7 @@ contract RewardsPool is Ownable {
     /// @notice Transfers the provided reward amount into RewardsPool and
     ///         creates a new, one-week reward interval starting from now.
     ///         Reward tokens from the previous reward interval that unlocked
-    ///         over the time will be available for withdrawal immediatelly.
+    ///         over the time will be available for withdrawal immediately.
     ///         Reward tokens from the previous interval that has not been yet
     ///         unlocked, are added to the new interval being created.
     /// @dev This function can be called only by the owner given that it creates

--- a/contracts/RiskManagerV1.sol
+++ b/contracts/RiskManagerV1.sol
@@ -81,7 +81,7 @@ contract RiskManagerV1 is IRiskManagerV1, Auctioneer, Ownable {
 
     /// @notice Governance delay that needs to pass before any risk manager
     ///         parameter change initiated by the governance takes effect.
-    uint256 public constant GOVERNANCE_TIME_DELAY = 12 hours;
+    uint256 public constant GOVERNANCE_DELAY = 12 hours;
 
     // See https://github.com/keep-network/tbtc/blob/v1.1.0/solidity/contracts/deposit/DepositStates.sol
     uint256 public constant DEPOSIT_FRAUD_LIQUIDATION_IN_PROGRESS_STATE = 9;
@@ -95,7 +95,7 @@ contract RiskManagerV1 is IRiskManagerV1, Auctioneer, Ownable {
     ///         from. The value can be updated by the governance in two steps.
     ///         First step is to begin the update process with the new value
     ///         and the second step is to finalize it after
-    ///         `GOVERNANCE_TIME_DELAY` has passed.
+    ///         `GOVERNANCE_DELAY` has passed.
     uint256 public bondAuctionThreshold; // percentage
     uint256 public newBondAuctionThreshold;
     uint256 public bondAuctionThresholdChangeInitiated;
@@ -110,7 +110,7 @@ contract RiskManagerV1 is IRiskManagerV1, Auctioneer, Ownable {
     ///         The value can be updated by the governance in two steps.
     ///         First step is to begin the update process with the new value
     ///         and the second step is to finalize it after
-    ///         `GOVERNANCE_TIME_DELAY` has passed.
+    ///         `GOVERNANCE_DELAY` has passed.
     uint256 public auctionLength;
     uint256 public newAuctionLength;
     uint256 public auctionLengthChangeInitiated;
@@ -120,7 +120,7 @@ contract RiskManagerV1 is IRiskManagerV1, Auctioneer, Ownable {
     ///         The value can be updated by the governance in two steps.
     ///         First step is to begin the update process with the new value
     ///         and the second step is to finalize it after
-    ///         `GOVERNANCE_TIME_DELAY` has passed.
+    ///         `GOVERNANCE_DELAY` has passed.
     ISignerBondsSwapStrategy public signerBondsSwapStrategy;
     ISignerBondsSwapStrategy public newSignerBondsSwapStrategy;
     uint256 public signerBondsSwapStrategyInitiated;
@@ -206,7 +206,7 @@ contract RiskManagerV1 is IRiskManagerV1, Auctioneer, Ownable {
         require(changeInitiatedTimestamp > 0, "Change not initiated");
         require(
             /* solhint-disable-next-line not-rely-on-time */
-            block.timestamp - changeInitiatedTimestamp >= GOVERNANCE_TIME_DELAY,
+            block.timestamp - changeInitiatedTimestamp >= GOVERNANCE_DELAY,
             "Governance delay has not elapsed"
         );
         _;
@@ -617,7 +617,7 @@ contract RiskManagerV1 is IRiskManagerV1, Auctioneer, Ownable {
         return
             GovernanceUtils.getRemainingChangeTime(
                 bondAuctionThresholdChangeInitiated,
-                GOVERNANCE_TIME_DELAY
+                GOVERNANCE_DELAY
             );
     }
 
@@ -632,7 +632,7 @@ contract RiskManagerV1 is IRiskManagerV1, Auctioneer, Ownable {
         return
             GovernanceUtils.getRemainingChangeTime(
                 auctionLengthChangeInitiated,
-                GOVERNANCE_TIME_DELAY
+                GOVERNANCE_DELAY
             );
     }
 
@@ -647,7 +647,7 @@ contract RiskManagerV1 is IRiskManagerV1, Auctioneer, Ownable {
         return
             GovernanceUtils.getRemainingChangeTime(
                 rewards.liquidationNotifierRewardAmountChangeInitiated,
-                GOVERNANCE_TIME_DELAY
+                GOVERNANCE_DELAY
             );
     }
 
@@ -662,7 +662,7 @@ contract RiskManagerV1 is IRiskManagerV1, Auctioneer, Ownable {
         return
             GovernanceUtils.getRemainingChangeTime(
                 rewards.liquidationNotifierRewardPercentageChangeInitiated,
-                GOVERNANCE_TIME_DELAY
+                GOVERNANCE_DELAY
             );
     }
 
@@ -677,7 +677,7 @@ contract RiskManagerV1 is IRiskManagerV1, Auctioneer, Ownable {
         return
             GovernanceUtils.getRemainingChangeTime(
                 rewards.liquidatedNotifierRewardAmountChangeInitiated,
-                GOVERNANCE_TIME_DELAY
+                GOVERNANCE_DELAY
             );
     }
 
@@ -692,7 +692,7 @@ contract RiskManagerV1 is IRiskManagerV1, Auctioneer, Ownable {
         return
             GovernanceUtils.getRemainingChangeTime(
                 rewards.liquidatedNotifierRewardPercentageChangeInitiated,
-                GOVERNANCE_TIME_DELAY
+                GOVERNANCE_DELAY
             );
     }
 
@@ -707,7 +707,7 @@ contract RiskManagerV1 is IRiskManagerV1, Auctioneer, Ownable {
         return
             GovernanceUtils.getRemainingChangeTime(
                 signerBondsSwapStrategyInitiated,
-                GOVERNANCE_TIME_DELAY
+                GOVERNANCE_DELAY
             );
     }
 

--- a/contracts/RiskManagerV1.sol
+++ b/contracts/RiskManagerV1.sol
@@ -101,7 +101,7 @@ contract RiskManagerV1 is IRiskManagerV1, Auctioneer, Ownable {
     uint256 public newBondAuctionThreshold;
     uint256 public bondAuctionThresholdChangeInitiated;
 
-    /// @notice The length with wich every new auction is opened. Auction length
+    /// @notice The length with which every new auction is opened. Auction length
     ///         is the amount of time it takes for the auction to get to 100%
     ///         of all collateral on offer, in seconds. This parameter value
     ///         should be updated and kept up to date based on the coverage pool
@@ -380,7 +380,7 @@ contract RiskManagerV1 is IRiskManagerV1, Auctioneer, Ownable {
     /// @notice Begins the auction length update process.
     /// @dev Can be called only by the contract owner. The auction length should
     ///      be adjusted very carefully. Total value locked of the coverage pool
-    ///      and minimum possible auction amount needs to be taken into account.
+    ///      and minimum possible auction amount need to be taken into account.
     /// @param _newAuctionLength New auction length in seconds
     function beginAuctionLengthUpdate(uint256 _newAuctionLength)
         external

--- a/contracts/RiskManagerV1.sol
+++ b/contracts/RiskManagerV1.sol
@@ -21,7 +21,7 @@ import "./GovernanceUtils.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
-import "./interfaces/IRiskManager.sol";
+import "./interfaces/IRiskManagerV1.sol";
 
 /// @title tBTC v1 Deposit contract interface
 /// @notice This is an interface with just a few function signatures of a main
@@ -75,7 +75,7 @@ interface ISignerBondsSwapStrategy {
 ///         in liquidation and signer bonds on offer reached the specific
 ///         threshold. In practice, it means no one is willing to purchase
 ///         signer bonds for that deposit on tBTC side.
-contract RiskManagerV1 is IRiskManager, Auctioneer, Ownable {
+contract RiskManagerV1 is IRiskManagerV1, Auctioneer, Ownable {
     using SafeERC20 for IERC20;
     using RiskManagerV1Rewards for RiskManagerV1Rewards.Storage;
 
@@ -255,7 +255,7 @@ contract RiskManagerV1 is IRiskManager, Auctioneer, Ownable {
     ///         coverage pool as a reward - underwriter tokens are transferred
     ///         to the notifier's address.
     /// @param  depositAddress liquidating tBTC deposit address
-    function notifyLiquidation(address depositAddress) external {
+    function notifyLiquidation(address depositAddress) external override {
         require(
             tbtcDepositToken.exists(uint256(uint160(depositAddress))),
             "Address is not a deposit contract"
@@ -314,7 +314,7 @@ contract RiskManagerV1 is IRiskManager, Auctioneer, Ownable {
     ///         a share in the coverage pool as a reward - underwriter tokens
     ///         are transferred to the notifier's address.
     /// @param  depositAddress liquidated tBTC Deposit address
-    function notifyLiquidated(address depositAddress) external {
+    function notifyLiquidated(address depositAddress) external override {
         require(
             depositToAuction[depositAddress] != address(0),
             "No auction for given deposit"

--- a/contracts/RiskManagerV1.sol
+++ b/contracts/RiskManagerV1.sol
@@ -14,14 +14,15 @@
 
 pragma solidity 0.8.4;
 
+import "./interfaces/IRiskManagerV1.sol";
 import "./Auctioneer.sol";
 import "./Auction.sol";
 import "./CoveragePoolConstants.sol";
 import "./GovernanceUtils.sol";
+
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
-import "./interfaces/IRiskManagerV1.sol";
 
 /// @title tBTC v1 Deposit contract interface
 /// @notice This is an interface with just a few function signatures of a main

--- a/contracts/SignerBondsManualSwap.sol
+++ b/contracts/SignerBondsManualSwap.sol
@@ -16,6 +16,7 @@ pragma solidity 0.8.4;
 
 import "./interfaces/IRiskManagerV1.sol";
 import "./RiskManagerV1.sol";
+
 import "@openzeppelin/contracts/access/Ownable.sol";
 
 /// @title SignerBondsManualSwap

--- a/contracts/SignerBondsManualSwap.sol
+++ b/contracts/SignerBondsManualSwap.sol
@@ -14,7 +14,7 @@
 
 pragma solidity 0.8.4;
 
-import "./interfaces/IRiskManager.sol";
+import "./interfaces/IRiskManagerV1.sol";
 import "./RiskManagerV1.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
@@ -37,7 +37,7 @@ contract SignerBondsManualSwap is ISignerBondsSwapStrategy, Ownable {
     ///        that will be responsible for swapping ETH and depositing
     ///        collateral to the coverage pool.
     function withdrawSignerBonds(
-        IRiskManager riskManager,
+        IRiskManagerV1 riskManager,
         uint256 amount,
         address payable recipient
     ) external onlyOwner {

--- a/contracts/SignerBondsUniswapV2.sol
+++ b/contracts/SignerBondsUniswapV2.sol
@@ -18,6 +18,7 @@ import "./interfaces/IRiskManagerV1.sol";
 import "./RiskManagerV1.sol";
 import "./CoveragePool.sol";
 import "./CoveragePoolConstants.sol";
+
 import "@openzeppelin/contracts/access/Ownable.sol";
 
 /// @notice Interface for the Uniswap v2 router.

--- a/contracts/SignerBondsUniswapV2.sol
+++ b/contracts/SignerBondsUniswapV2.sol
@@ -14,7 +14,7 @@
 
 pragma solidity 0.8.4;
 
-import "./interfaces/IRiskManager.sol";
+import "./interfaces/IRiskManagerV1.sol";
 import "./RiskManagerV1.sol";
 import "./CoveragePool.sol";
 import "./CoveragePoolConstants.sol";
@@ -191,7 +191,7 @@ contract SignerBondsUniswapV2 is ISignerBondsSwapStrategy, Ownable {
     /// @param riskManager Address of the risk manager which holds the bonds.
     /// @param amount Amount to swap.
     function swapSignerBondsOnUniswapV2(
-        IRiskManager riskManager,
+        IRiskManagerV1 riskManager,
         uint256 amount
     ) external {
         require(amount > 0, "Amount must be greater than 0");

--- a/contracts/UnderwriterToken.sol
+++ b/contracts/UnderwriterToken.sol
@@ -14,10 +14,9 @@
 
 pragma solidity 0.8.4;
 
-import "./AssetPool.sol";
-
 import "./interfaces/IUnderwriterToken.sol";
 import "./ERC20WithPermit.sol";
+import "./AssetPool.sol";
 
 /// @title  UnderwriterToken
 /// @notice Underwriter tokens represent an ownership share in the underlying

--- a/contracts/interfaces/IAssetPool.sol
+++ b/contracts/interfaces/IAssetPool.sol
@@ -14,6 +14,12 @@
 
 pragma solidity 0.8.4;
 
+/// @title Asset Pool interface
+/// @notice Asset Pool accepts a single ERC20 token as collateral, and returns
+///         an underwriter token. For example, an asset pool might accept deposits
+///         in KEEP in return for covKEEP underwriter tokens. Underwriter tokens
+///         represent an ownership share in the underlying collateral of the
+///         Asset Pool.
 interface IAssetPool {
     /// @notice Accepts the given amount of collateral token as a deposit and
     ///         mints underwriter tokens representing pool's ownership.

--- a/contracts/interfaces/IAssetPoolUpgrade.sol
+++ b/contracts/interfaces/IAssetPoolUpgrade.sol
@@ -14,6 +14,9 @@
 
 pragma solidity 0.8.4;
 
+/// @title Asset Pool upgrade interface
+/// @notice Interface that has to be implemented by an Asset Pool accepting
+///         upgrades from another asset pool.
 interface IAssetPoolUpgrade {
     /// @notice Accepts the given underwriter with collateral tokens amount as a
     ///         deposit. In exchange new underwriter tokens will be calculated,

--- a/contracts/interfaces/IAuction.sol
+++ b/contracts/interfaces/IAuction.sol
@@ -14,12 +14,19 @@
 
 pragma solidity 0.8.4;
 
+/// @title Auction interface
+/// @notice Auction runs a linear falling-price auction against a diverse
+///         basket of assets held in a collateral pool. Auctions are taken using
+///         a single asset. Over time, a larger and larger portion of the assets
+///         are on offer, eventually hitting 100% of the backing collateral
 interface IAuction {
-    /// @notice Takes an offer from an auction buyer.
-    /// @dev There are two possible ways to take an offer from a buyer. The first
-    ///      one is to buy entire auction with the amount desired for this auction.
-    ///      The other way is to buy a portion of an auction. In this case an
-    ///      auction depleting rate is increased.
+    /// @notice Takes an offer from an auction buyer. There are two possible
+    ///         ways to take an offer from a buyer. The first one is to buy
+    ///         entire auction with the amount desired for this auction.
+    ///         The other way is to buy a portion of an auction. In this case an
+    ///         auction depleting rate is increased.
+    /// @dev The implementation is not guaranteed to be protecting against
+    ///      frontrunning. See `AuctionBidder` for an example protection.
     function takeOffer(uint256 amount) external;
 
     /// @notice How much of the collateral pool can currently be purchased at

--- a/contracts/interfaces/IERC20WithPermit.sol
+++ b/contracts/interfaces/IERC20WithPermit.sol
@@ -16,7 +16,7 @@ pragma solidity 0.8.4;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
-/// @title  IERC20WithPermit
+/// @title  ERC20 with `permit` interface
 /// @notice Burnable ERC20 token with EIP2612 permit functionality. Users can
 ///         authorize a transfer of their token with a signature conforming
 ///         EIP712 standard instead of an on-chain transaction from their

--- a/contracts/interfaces/IRiskManagerV1.sol
+++ b/contracts/interfaces/IRiskManagerV1.sol
@@ -12,6 +12,8 @@
 
 // SPDX-License-Identifier: MIT
 
+pragma solidity 0.8.4;
+
 /// @title Interface for tBTC v1 Risk Manager
 /// @notice Risk Manager is a smart contract with the exclusive right to claim
 ///         coverage from the coverage pool. Demanding coverage is akin to

--- a/contracts/interfaces/IRiskManagerV1.sol
+++ b/contracts/interfaces/IRiskManagerV1.sol
@@ -13,8 +13,17 @@
 // SPDX-License-Identifier: MIT
 
 /// @title Interface for tBTC v1 Risk Manager
-/// @notice tBTC v1 Risk Manager interface with all functions external contracts
-///         are interested in.
+/// @notice Risk Manager is a smart contract with the exclusive right to claim
+///         coverage from the coverage pool. Demanding coverage is akin to
+///         filing a claim in traditional insurance and processing your own
+///         claim. The risk manager holds an incredibly privileged position,
+///         because the ability to claim coverage of an arbitrarily large
+///         position could bankrupt the coverage pool.
+///         tBTC v1 risk manager demands coverage by opening an auction for TBTC
+///         and liquidating portion of the coverage pool when tBTC v1 deposit is
+///         in liquidation and signer bonds on offer reached the specific
+///         threshold. In practice, it means no one is willing to purchase
+///         signer bonds for that deposit on tBTC side.
 interface IRiskManagerV1 {
     /// @notice Notifies the risk manager about tBTC deposit in liquidation
     ///         state for which signer bonds on offer passed the threshold

--- a/contracts/interfaces/IRiskManagerV1.sol
+++ b/contracts/interfaces/IRiskManagerV1.sol
@@ -12,15 +12,42 @@
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.4;
+/// @title Interface for tBTC v1 Risk Manager
+/// @notice tBTC v1 Risk Manager interface with all functions external contracts
+///         are interested in.
+interface IRiskManagerV1 {
+    /// @notice Notifies the risk manager about tBTC deposit in liquidation
+    ///         state for which signer bonds on offer passed the threshold
+    ///         expected by the risk manager. In practice, it means no one else
+    ///         is willing to purchase signer bonds from that deposit so the
+    ///         risk manager should open an auction to collect TBTC and purchase
+    ///         those bonds liquidating part of the coverage pool. If there is
+    ///         enough TBTC surplus from earlier auctions accumulated by the
+    ///         risk manager, bonds are purchased right away without opening an
+    ///         auction. Notifier calling this function receives a share in the
+    ///         coverage pool as a reward - underwriter tokens are transferred
+    ///         to the notifier's address.
+    /// @param  depositAddress liquidating tBTC deposit address
+    function notifyLiquidation(address depositAddress) external;
 
-/// @title IRiskManager
-interface IRiskManager {
+    /// @notice Notifies the risk manager about tBTC deposit liquidated outside
+    ///         the coverage pool for which the risk manager opened an auction
+    ///         earlier (as a result of `notifyLiquidation` call). Function
+    ///         closes the auction early and collects TBTC surplus from the
+    ///         auction in case the auction was partially taken before the
+    ///         deposit got liquidated. Notifier calling this function receives
+    ///         a share in the coverage pool as a reward - underwriter tokens
+    ///         are transferred to the notifier's address.
+    /// @param  depositAddress liquidated tBTC Deposit address
+    function notifyLiquidated(address depositAddress) external;
+
     /// @notice Withdraws the given amount of accumulated signer bonds.
+    /// @dev Usually used by `ISignerBondsSwapStrategy` implementations.
     /// @param amount Amount of signer bonds being withdrawn.
     function withdrawSignerBonds(uint256 amount) external;
 
-    /// @return True if there are open auctions managed by the risk manager.
-    ///         Returns false otherwise.
+    /// @notice Returns true if there are open auctions managed by the risk
+    ///         manager. Returns false otherwise.
+    /// @dev Usually used by `ISignerBondsSwapStrategy` implementations.
     function hasOpenAuctions() external view returns (bool);
 }

--- a/contracts/interfaces/IUnderwriterToken.sol
+++ b/contracts/interfaces/IUnderwriterToken.sol
@@ -16,7 +16,7 @@ pragma solidity 0.8.4;
 
 import "./IERC20WithPermit.sol";
 
-/// @title  IUnderwriterToken
+/// @title  Underwriter Token
 /// @notice Underwriter tokens represent an ownership share in the underlying
 ///         collateral of the asset-specific pool. Underwriter tokens are minted
 ///         when a user deposits ERC20 tokens into asset-specific pool and they


### PR DESCRIPTION
Closes #82 
Depends on #124

Some final touches packed in one PR, specifically:
- Solidity documentation improvements: better descriptions, fixed typos, more information on important fields and functions.
- Improvements to Risk Manager interface

  `IRiskManager` has been renamed to `IRiskManagerV1`. Also, added
`notifyLiquidation` and `notifyLiquidated` functions there and improved
docs.

  `IRiskManager` was not a generic interface that could be implemented by
any risk manager because of the notion of signer bonds and the fact they
are getting withdrawn from the risk manager. Instead of having only
functions used by swap strategies there, we can have there all functions
external contracts are interested in.

  Swap strategies still can work with any implementation of a risk manager
for tBTC v1, same as before. They were never generic enough to work with
any risk manager because that manager needed to have a notion of signer
bonds, hence liquidation as well.
- Renamed `RiskManagerV1.GOVERNANCE_TIME_DELAY` to `GOVERNANCE_DELAY `

  Renamed the constant to keep it aligned with "governance delay" used by
the asset pool. Even in the risk manager, we have
onlyAfterGovernanceDelay modifier.

- Reordered and aligned imports 

  First goes internal interfaces. Second goes internal contracts. Then, external interfaces and contracts such as OpenZeppelin ones.