### PR TITLE
Add an installation script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
-artifacts/
+artifacts
+build/
 cache/
 typechain/
 deployments/

--- a/deploy/07_deploy_coverage_pool.js
+++ b/deploy/07_deploy_coverage_pool.js
@@ -9,7 +9,7 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
     args: [AssetPool.address],
     log: true,
   })
-  
+
   const assetPool = await ethers.getContractAt("AssetPool", AssetPool.address)
   const underwriterToken = await ethers.getContractAt(
     "UnderwriterToken",

--- a/deploy/07_deploy_coverage_pool.js
+++ b/deploy/07_deploy_coverage_pool.js
@@ -2,12 +2,22 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
   const { deploy } = deployments
   const { deployer } = await getNamedAccounts()
   const AssetPool = await deployments.get("AssetPool")
+  const UnderwriterToken = await deployments.get("UnderwriterToken")
 
-  await deploy("CoveragePool", {
+  const CoveragePool = await deploy("CoveragePool", {
     from: deployer,
     args: [AssetPool.address],
     log: true,
   })
+  
+  const assetPool = await ethers.getContractAt("AssetPool", AssetPool.address)
+  const underwriterToken = await ethers.getContractAt(
+    "UnderwriterToken",
+    UnderwriterToken.address
+  )
+
+  await assetPool.transferOwnership(CoveragePool.address)
+  await underwriterToken.transferOwnership(AssetPool.address)
 }
 
 module.exports.tags = ["CoveragePool"]

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -22,8 +22,8 @@ module.exports = {
       },
     },
     local: {
-      url: "http://localhost:8545"
-    }
+      url: "http://localhost:8545",
+    },
   },
 
   namedAccounts: {

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -6,7 +6,9 @@ module.exports = {
   solidity: {
     version: "0.7.6",
   },
-
+  paths: {
+    artifacts: "./build",
+  },
   networks: {
     hardhat: {
       forking: {

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -19,6 +19,9 @@ module.exports = {
           process.env.FORKING_BLOCK && parseInt(process.env.FORKING_BLOCK),
       },
     },
+    local: {
+      url: "http://localhost:8545"
+    }
   },
 
   namedAccounts: {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+set -euo pipefail
+
+LOG_START='\n\e[1;36m'  # new line + bold + cyan
+LOG_END='\n\e[0m'       # new line + reset
+DONE_START='\n\e[1;32m' # new line + bold + green
+DONE_END='\n\n\e[0m'    # new line + reset
+
+COVERAGE_POOL_PATH=$(realpath $(dirname $0)/../)
+
+# Defaults, can be overwritten by env variables/input parameters
+NETWORK_DEFAULT="local"
+KEEP_TOKEN_ADDRESS=${KEEP_TOKEN_ADDRESS:-""}
+TBTC_TOKEN_ADDRESS=${TBTC_TOKEN_ADDRESS:-""}
+TBTC_DEPOSIT_TOKEN_ADDRESS=${TBTC_DEPOSIT_TOKEN_ADDRESS:-""}
+UNISWAP_ROUTER_V2_ADDRESS=${UNISWAP_ROUTER_V2_ADDRESS:-""}
+INITIAL_SWAP_STRATEGY=${INITIAL_SWAP_STRATEGY:-""}
+
+help() {
+  echo -e "\nUsage: ENV_VAR(S) $0" \
+    "--network <network>"
+
+  echo -e "\nEnvironment variables:\n"
+  echo -e "\tKEEP_TOKEN_ADDRESS: Determines the address of KEEP token contract"
+  echo -e "\tTBTC_TOKEN_ADDRESS: Determines the address of TBTC token contract"
+  echo -e "\tTBTC_DEPOSIT_TOKEN_ADDRESS: Determines the address of TDT token contract"
+  echo -e "\tUNISWAP_ROUTER_V2_ADDRESS: Determines the address of Uniswap v2 router"
+  echo -e "\tINITIAL_SWAP_STRATEGY: Allows setting the initial swap strategy which will be used by the risk manager." \
+    "This should be the name of one of the ISignerBondsSwapStrategy implementations."
+
+
+  echo -e "\nCommand line arguments:\n"
+  echo -e "\t--network: Ethereum network." \
+    "Available networks and settings are specified in 'hardhat.config.js'"
+  exit 1 # Exit script after printing help
+}
+
+# Transform long options to short ones
+for arg in "$@"; do
+  shift
+  case "$arg" in
+  "--network") set -- "$@" "-n" ;;
+  "--help") set -- "$@" "-h" ;;
+  *) set -- "$@" "$arg" ;;
+  esac
+done
+
+# Parse short options
+OPTIND=1
+while getopts "n:mh" opt; do
+  case "$opt" in
+  n) network="$OPTARG" ;;
+  m) contracts_only=true ;;
+  h) help ;;
+  ?) help ;; # Print help in case parameter is non-existent
+  esac
+done
+shift $(expr $OPTIND - 1) # remove options from positional parameters
+
+# Overwrite default properties
+NETWORK=${network:-$NETWORK_DEFAULT}
+
+printf "${LOG_START}Network: $NETWORK ${LOG_END}"
+
+# Run script.
+printf "${LOG_START}Starting installation...${LOG_END}"
+
+printf "${LOG_START}Installing dependencies...${LOG_END}"
+yarn install
+
+printf "${LOG_START}Migrating contracts...${LOG_END}"
+KEEP_TOKEN_ADDRESS=$KEEP_TOKEN_ADDRESS \
+TBTC_TOKEN_ADDRESS=$TBTC_TOKEN_ADDRESS \
+TBTC_DEPOSIT_TOKEN_ADDRESS=$TBTC_DEPOSIT_TOKEN_ADDRESS \
+UNISWAP_ROUTER_V2_ADDRESS=$UNISWAP_ROUTER_V2_ADDRESS \
+INITIAL_SWAP_STRATEGY=$INITIAL_SWAP_STRATEGY \
+yarn deploy --reset --network $NETWORK
+
+printf "${LOG_START}Creating links...${LOG_END}"
+ln -sf "deployments/${NETWORK}" artifacts
+
+printf "${DONE_START}Installation completed!${DONE_END}"

--- a/slither.config.json
+++ b/slither.config.json
@@ -1,4 +1,5 @@
 {
   "detectors_to_exclude": "assembly,naming-convention,solc-version,timestamp,too-many-digits",
-  "filter_paths": "contracts/test|node_modules"
+  "filter_paths": "contracts/test|node_modules",
+  "hardhat_artifacts_directory": "./build"
 }

--- a/test/AssetPool.test.js
+++ b/test/AssetPool.test.js
@@ -7,8 +7,6 @@ const {
   to1ePrecision,
 } = require("./helpers/contract-test-helpers")
 
-const RewardsPoolJSON = require("../artifacts/contracts/RewardsPool.sol/RewardsPool.json")
-
 describe("AssetPool", () => {
   let assetPool
   let coveragePool
@@ -53,9 +51,9 @@ describe("AssetPool", () => {
     await underwriterToken.transferOwnership(assetPool.address)
 
     rewardsPoolAddress = await assetPool.rewardsPool()
-    rewardsPool = new ethers.Contract(
+    rewardsPool = await ethers.getContractAt(
+      "RewardsPool",
       rewardsPoolAddress,
-      RewardsPoolJSON.abi,
       rewardManager
     )
 

--- a/test/Auction.test.js
+++ b/test/Auction.test.js
@@ -9,7 +9,6 @@ const {
   impersonateAccount,
 } = require("./helpers/contract-test-helpers")
 
-const AuctionJSON = require("../artifacts/contracts/Auction.sol/Auction.json")
 const { BigNumber } = ethers
 
 // amount of test tokens that an auction (aka spender) is allowed
@@ -637,7 +636,7 @@ describe("Auction", () => {
     const events = pastEvents(receipt, auctioneer, "AuctionCreated")
     const auctionAddress = events[0].args["auctionAddress"]
 
-    return new ethers.Contract(auctionAddress, AuctionJSON.abi, owner)
+    return await ethers.getContractAt("Auction", auctionAddress, owner)
   }
 
   async function approveTestTokenForAuction(auctionAddress) {

--- a/test/AuctionBidder.test.js
+++ b/test/AuctionBidder.test.js
@@ -1,11 +1,12 @@
 const chai = require("chai")
-
 const expect = chai.expect
+
+const hre = require("hardhat")
 const { to1ePrecision, to1e18 } = require("./helpers/contract-test-helpers")
 
 const { deployMockContract } = require("@ethereum-waffle/mock-contract")
-const AuctionJSON = require("../artifacts/contracts/Auction.sol/Auction.json")
-const CoveragePoolJSON = require("../artifacts/contracts/CoveragePool.sol/CoveragePool.json")
+const AuctionJSON = hre.artifacts.readArtifactSync("Auction")
+const CoveragePoolJSON = hre.artifacts.readArtifactSync("CoveragePool")
 
 const { BigNumber } = ethers
 

--- a/test/Auctioneer.test.js
+++ b/test/Auctioneer.test.js
@@ -7,8 +7,6 @@ const {
   increaseTime,
 } = require("./helpers/contract-test-helpers")
 
-const AuctionJSON = require("../artifacts/contracts/Auction.sol/Auction.json")
-
 const auctionLength = 86400 // 24h in sec
 const auctionAmountDesired = to1e18(1) // ex. 1 TBTC
 const testTokensToMint = to1e18(1)
@@ -84,7 +82,7 @@ describe("Auctioneer", () => {
       const events = pastEvents(receipt, auctioneer, "AuctionCreated")
       auctionAddress = events[0].args["auctionAddress"]
 
-      auction = new ethers.Contract(auctionAddress, AuctionJSON.abi, owner)
+      auction = await ethers.getContractAt("Auction", auctionAddress, owner)
 
       await testToken
         .connect(bidder)
@@ -252,7 +250,7 @@ describe("Auctioneer", () => {
       const events = pastEvents(receipt, auctioneer, "AuctionCreated")
       auctionAddress = events[0].args["auctionAddress"]
 
-      auction = new ethers.Contract(auctionAddress, AuctionJSON.abi, owner)
+      auction = await ethers.getContractAt("Auction", auctionAddress, owner)
 
       await testToken
         .connect(bidder)

--- a/test/RiskManagerV1.test.js
+++ b/test/RiskManagerV1.test.js
@@ -1,5 +1,6 @@
 const chai = require("chai")
 const expect = chai.expect
+const hre = require("hardhat")
 const {
   to1e18,
   to1ePrecision,
@@ -8,8 +9,7 @@ const {
 } = require("./helpers/contract-test-helpers")
 
 const { deployMockContract } = require("@ethereum-waffle/mock-contract")
-const ITBTCDepositToken = require("../artifacts/contracts/RiskManagerV1.sol/ITBTCDepositToken.json")
-const Auction = require("../artifacts/contracts/Auction.sol/Auction.json")
+const ITBTCDepositToken = hre.artifacts.readArtifactSync("ITBTCDepositToken")
 
 const auctionLotSize = to1e18(1)
 const auctionLength = 86400 // 24h
@@ -350,7 +350,7 @@ describe("RiskManagerV1", () => {
         // Simulate that someone takes a partial offer on the auction.
         await tbtcToken.mint(bidder.address, auctionLotSize)
         await tbtcToken.connect(bidder).approve(auctionAddress, auctionLotSize)
-        auction = new ethers.Contract(auctionAddress, Auction.abi, owner)
+        auction = await ethers.getContractAt("Auction", auctionAddress, owner)
         await auction.connect(bidder).takeOffer(to1ePrecision(25, 16))
 
         // Simulate that deposit was liquidated by someone else.

--- a/test/SignerBondsUniswapV2.test.js
+++ b/test/SignerBondsUniswapV2.test.js
@@ -1,10 +1,12 @@
 const chai = require("chai")
 const expect = chai.expect
+const hre = require("hardhat")
 const { BigNumber } = ethers
 const { deployMockContract } = require("@ethereum-waffle/mock-contract")
 const { to1e18, lastBlockTime } = require("./helpers/contract-test-helpers")
-const CoveragePool = require("../artifacts/contracts/CoveragePool.sol/CoveragePool.json")
-const IUniswapV2Pair = require("../artifacts/contracts/SignerBondsUniswapV2.sol/IUniswapV2Pair.json")
+
+const CoveragePool = hre.artifacts.readArtifactSync("CoveragePool")
+const IUniswapV2Pair = hre.artifacts.readArtifactSync("IUniswapV2Pair")
 
 describe("SignerBondsUniswapV2", () => {
   let governance

--- a/test/integration/liquidation.test.js
+++ b/test/integration/liquidation.test.js
@@ -1,8 +1,8 @@
 const { expect } = require("chai")
+const hre = require("hardhat")
 const { to1e18 } = require("../helpers/contract-test-helpers")
 const { deployMockContract } = require("@ethereum-waffle/mock-contract")
-const Auction = require("../../artifacts/contracts/Auction.sol/Auction.json")
-const ITBTCDepositToken = require("../../artifacts/contracts/RiskManagerV1.sol/ITBTCDepositToken.json")
+const ITBTCDepositToken = hre.artifacts.readArtifactSync("ITBTCDepositToken")
 
 describe("Integration -- liquidation", () => {
   const auctionLength = 86400 // 24h
@@ -130,7 +130,7 @@ describe("Integration -- liquidation", () => {
     const auctionAddress = await riskManagerV1.depositToAuction(
       tbtcDeposit.address
     )
-    const auction = new ethers.Contract(auctionAddress, Auction.abi, bidder)
+    const auction = await ethers.getContractAt("Auction", auctionAddress, bidder)
     await tbtcToken.connect(bidder).approve(auction.address, lotSize)
     return auction
   }

--- a/test/integration/liquidation.test.js
+++ b/test/integration/liquidation.test.js
@@ -130,7 +130,11 @@ describe("Integration -- liquidation", () => {
     const auctionAddress = await riskManagerV1.depositToAuction(
       tbtcDeposit.address
     )
-    const auction = await ethers.getContractAt("Auction", auctionAddress, bidder)
+    const auction = await ethers.getContractAt(
+      "Auction",
+      auctionAddress,
+      bidder
+    )
     await tbtcToken.connect(bidder).approve(auction.address, lotSize)
     return auction
   }

--- a/test/system/liquidation.test.js
+++ b/test/system/liquidation.test.js
@@ -7,6 +7,9 @@ const {
   ZERO_ADDRESS,
   increaseTime,
 } = require("../helpers/contract-test-helpers")
+const hre = require("hardhat")
+
+const Auction = hre.artifacts.readArtifactSync("Auction")
 
 const describeFn =
   process.env.NODE_ENV === "system-test" ? describe : describe.skip
@@ -152,7 +155,7 @@ describeFn("System -- liquidation", () => {
       const auctionAddress = await riskManagerV1.depositToAuction(
         tbtcDeposit.address
       )
-      auction = await ethers.getContractAt("Auction", auctionAddress, bidder)
+      auction = new ethers.Contract(auctionAddress, Auction.abi, bidder)
       await tbtcToken.connect(bidder).approve(auction.address, lotSize)
       bidderInitialBalance = await tbtcToken.balanceOf(bidder.address)
       tx = await auction.takeOffer(lotSize)

--- a/test/system/liquidation.test.js
+++ b/test/system/liquidation.test.js
@@ -7,7 +7,6 @@ const {
   ZERO_ADDRESS,
   increaseTime,
 } = require("../helpers/contract-test-helpers")
-const Auction = require("../../artifacts/contracts/Auction.sol/Auction.json")
 
 const describeFn =
   process.env.NODE_ENV === "system-test" ? describe : describe.skip
@@ -153,7 +152,7 @@ describeFn("System -- liquidation", () => {
       const auctionAddress = await riskManagerV1.depositToAuction(
         tbtcDeposit.address
       )
-      auction = new ethers.Contract(auctionAddress, Auction.abi, bidder)
+      auction = await ethers.getContractAt("Auction", auctionAddress, bidder)
       await tbtcToken.connect(bidder).approve(auction.address, lotSize)
       bidderInitialBalance = await tbtcToken.balanceOf(bidder.address)
       tx = await auction.takeOffer(lotSize)


### PR DESCRIPTION
Depends on: #103

This PR adds an installation script that:
* installs yarn dependencies,
* deploys coverage pools contracts,
* creates a symbolic link that points to the deployed contract artifacts. This will help to keep consistency between `keep-network` packages. All `keep-network` packages store the contract artifacts in `artifacts` dir eg `@keep-network/keep-core/artifacts/<contract>.json`.

This script will help to run the Keep Token Dashboard locally.

Here we also get rid of the imports that use the relative path to the contract artifact. Instead of this we should use the Hardhat helpers:

**To get the Ethers Contract instance at a given address:**
```
const contract = await ethers.getContractAt(contractName, address, signer)
```

**To get the contract artifact:**
```
const hre = require("hardhat")
const contract = hre.artifacts.readArtifactSync(contractName)