### PR TITLE
Small final touches on system tests

### DIFF
--- a/test/system/constants.js
+++ b/test/system/constants.js
@@ -3,6 +3,7 @@ module.exports.keepTokenAddress = "0x85Eee30c52B0b379b046Fb0F85F4f3Dc3009aFEC"
 module.exports.tbtcDepositTokenAddress =
   "0x10b66bd1e3b5a936b7f8dbc5976004311037cdf0"
 // Use this address when only 1 deposit is needed for testing
+// This deposit is getting liquidated as a result of redemption signature timeout.
 // https://allthekeeps.com/deposit/0x55d8b1dd88e60d12c81b5479186c15d07555db9d)
 module.exports.depositAddress1 = "0x55d8b1dd88e60d12c81b5479186c15d07555db9d"
 // Use these 2 deposits below when you need to test functionality with deposits
@@ -10,8 +11,10 @@ module.exports.depositAddress1 = "0x55d8b1dd88e60d12c81b5479186c15d07555db9d"
 // At the time of implementing tests, Hardhat can increase block.timestamp but
 // cannot mine and jump into the future block. Mining blocks must be done manually,
 // however it can either take a lot of time or cause internal failure.
+// This deposit is getting liquidated as a result of redemption signature timeout.
 // https://allthekeeps.com/deposit/0x8495732aecd7f132eaab61f64858ccc73475973f
 module.exports.depositAddress2 = "0x8495732aecd7f132eaab61f64858ccc73475973f"
+// This deposit is getting liquidated as a result of undercollateralization.
 // https://allthekeeps.com/deposit/0xfc9c50fd44879bd7085edd311bc8e2b7d3e41595
 module.exports.depositAddress3 = "0xfc9c50fd44879bd7085edd311bc8e2b7d3e41595"
 module.exports.bidderAddress1 = "0xa0216ED2202459068a750bDf74063f677613DA34"

--- a/test/system/liquidation.test.js
+++ b/test/system/liquidation.test.js
@@ -163,14 +163,14 @@ describeFn("System -- liquidation", () => {
     it("should transfer collateral tokens to the bidder", async () => {
       expect(await collateralToken.balanceOf(bidder.address)).to.be.closeTo(
         to1e18(60000), // 30% of the initial asset pool
-        to1e18(100) // 100 KEEP tokens precision
+        to1e18(20) // 20 KEEP tokens precision
       )
     })
 
     it("should adjust asset pool's collateral tokens after the claim", async () => {
       expect(await collateralToken.balanceOf(assetPool.address)).to.be.closeTo(
         to1e18(140000), // 70% of the initial asset pool
-        to1e18(100) // 100 KEEP tokens precision
+        to1e18(20) // 20 KEEP tokens precision
       )
     })
 

--- a/test/system/liquidation.test.js
+++ b/test/system/liquidation.test.js
@@ -137,14 +137,18 @@ describeFn("System -- liquidation", () => {
       expect(await auction.isOpen()).to.be.false
     })
 
-    it("should liquidate the deposit", async () => {
-      // Auction bidder has spend their TBTC.
+    it("should spend bidder's TBTC", async () => {
+      // Auction bidder has spent their TBTC.
       const bidderCurrentBalance = await tbtcToken.balanceOf(bidder.address)
       expect(bidderInitialBalance.sub(bidderCurrentBalance)).to.equal(lotSize)
+    })
 
+    it("should liquidate the deposit", async () => {
       // Deposit has been liquidated.
       expect(await tbtcDeposit1.currentState()).to.equal(11) // LIQUIDATED
+    })
 
+    it("should send ETH from purchased bonds to the risk manager", async () => {
       // The percentage of signer bonds that should be sent to the risk manager
       // contract consists of the initial 66% and a portion of the remaining 34%
       // that depends on the time passed before take offer. The percentage


### PR DESCRIPTION
Refs: #83
Three minor changes to system tests:
- Extracted some assertions into separate `it` clauses to keep them consistent with other tests,
- Cranked assertion precision from 100 to 20 KEEP,
- Added a note on why the system test deposit is getting liquidated.