### PR TITLE
Use hardhat-deploy-ethers plugin

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -1,4 +1,5 @@
 require("@nomiclabs/hardhat-waffle")
+require("@nomiclabs/hardhat-ethers")
 require("hardhat-gas-reporter")
 require("hardhat-deploy")
 require("solidity-coverage")

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "@openzeppelin/contracts": "^4.1.0"
   },
   "devDependencies": {
-    "@nomiclabs/hardhat-ethers": "^2.0.2",
+    "@nomiclabs/hardhat-ethers": "npm:hardhat-deploy-ethers",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "chai": "^4.3.4",
     "eslint": "^6.8.0",

--- a/test/AssetPool.test.js
+++ b/test/AssetPool.test.js
@@ -32,9 +32,9 @@ describe("AssetPool", () => {
   const withdrawalTimeout = 2 * 24 * 3600
 
   beforeEach(async () => {
-    coveragePool = await ethers.getSigner(1)
-    rewardManager = await ethers.getSigner(2)
-    thirdParty = await ethers.getSigner(3)
+    coveragePool = (await ethers.getSigners())[1]
+    rewardManager = (await ethers.getSigners())[2]
+    thirdParty = (await ethers.getSigners())[3]
 
     const TestToken = await ethers.getContractFactory("TestToken")
     collateralToken = await TestToken.deploy()
@@ -64,7 +64,7 @@ describe("AssetPool", () => {
     await collateralToken.mint(rewardManager.address, to1e18(1000000))
 
     const createUnderwriterWithTokens = async (index) => {
-      const underwriter = await ethers.getSigner(index)
+      const underwriter = (await ethers.getSigners())[index]
       await collateralToken.mint(
         underwriter.address,
         underwriterInitialCollateralBalance
@@ -305,7 +305,7 @@ describe("AssetPool", () => {
 
     context("when done by the owner", () => {
       it("should transfer claimed tokens to the recipient", async () => {
-        const claimRecipient = await ethers.getSigner(15)
+        const claimRecipient = (await ethers.getSigners())[15]
         await assetPool
           .connect(coveragePool)
           .claim(claimRecipient.address, to1e18(90))
@@ -315,7 +315,7 @@ describe("AssetPool", () => {
       })
 
       it("should emit CoverageClaimed event", async () => {
-        const claimRecipient = await ethers.getSigner(15)
+        const claimRecipient = (await ethers.getSigners())[15]
         const claimAmount = to1e18(91)
         const tx = await assetPool
           .connect(coveragePool)
@@ -340,7 +340,7 @@ describe("AssetPool", () => {
       })
 
       it("should first transfer released rewards to asset pool", async () => {
-        const claimRecipient = await ethers.getSigner(15)
+        const claimRecipient = (await ethers.getSigners())[15]
         // 70 / 7  = 10 reward tokens released every day
         // 200 + 10 tokens in the asset pool
         // 205 claimed (more than deposited!), 5 stays in the pool
@@ -1044,7 +1044,7 @@ describe("AssetPool", () => {
 
     context("when a new asset pool address does not match", () => {
       it("should revert", async () => {
-        const fakeAssetPool = await ethers.getSigner(5)
+        const fakeAssetPool = (await ethers.getSigners())[5]
         await assetPool
           .connect(coveragePool)
           .approveNewAssetPoolUpgrade(fakeAssetPool.address)

--- a/test/Auction.test.js
+++ b/test/Auction.test.js
@@ -31,9 +31,9 @@ describe("Auction", () => {
     const Auction = await ethers.getContractFactory("Auction")
     const CoveragePoolStub = await ethers.getContractFactory("CoveragePoolStub")
 
-    owner = await ethers.getSigner(0)
-    bidder1 = await ethers.getSigner(1)
-    bidder2 = await ethers.getSigner(2)
+    owner = (await ethers.getSigners())[0]
+    bidder1 = (await ethers.getSigners())[1]
+    bidder2 = (await ethers.getSigners())[2]
 
     masterAuction = await Auction.deploy()
     await masterAuction.deployed()

--- a/test/AuctionBidder.test.js
+++ b/test/AuctionBidder.test.js
@@ -16,8 +16,8 @@ describe("AuctionBidder", () => {
   let auctionBidder
 
   before(async () => {
-    owner = await ethers.getSigner(0)
-    bidder = await ethers.getSigner(1)
+    owner = (await ethers.getSigners())[0]
+    bidder = (await ethers.getSigners())[1]
 
     mockAuction = await deployMockContract(owner, AuctionJSON.abi)
     mockCoveragePool = await deployMockContract(owner, CoveragePoolJSON.abi)

--- a/test/Auctioneer.test.js
+++ b/test/Auctioneer.test.js
@@ -20,8 +20,8 @@ describe("Auctioneer", () => {
   let testToken
 
   beforeEach(async () => {
-    owner = await ethers.getSigner(0)
-    bidder = await ethers.getSigner(1)
+    owner = (await ethers.getSigners())[0]
+    bidder = (await ethers.getSigners())[1]
 
     const AuctioneerStub = await ethers.getContractFactory("AuctioneerStub")
     const TestToken = await ethers.getContractFactory("TestToken")

--- a/test/CoveragePool.test.js
+++ b/test/CoveragePool.test.js
@@ -21,19 +21,19 @@ describe("CoveragePool", () => {
 
   beforeEach(async () => {
     // Governance that owns Coverage Pool
-    governance = await ethers.getSigner(1)
+    governance = (await ethers.getSigners())[1]
     // Underwriter that will deposit some amount of tokens to Asset Pool
-    underwriter = await ethers.getSigner(2)
+    underwriter = (await ethers.getSigners())[2]
     // Recipient that will receive seized funds
-    recipient = await ethers.getSigner(3)
+    recipient = (await ethers.getSigners())[3]
     // The main risk manager
-    riskManager = await ethers.getSigner(4)
+    riskManager = (await ethers.getSigners())[4]
     // Another risk manager
-    anotherRiskManager = await ethers.getSigner(5)
+    anotherRiskManager = (await ethers.getSigners())[5]
     // Account that is not authorized to call functions on Coverage Pool
-    thirdParty = await ethers.getSigner(6)
+    thirdParty = (await ethers.getSigners())[6]
     // Account funding Asset Pool with rewards
-    const rewardsManager = await ethers.getSigner(7)
+    const rewardsManager = (await ethers.getSigners())[7]
 
     const TestToken = await ethers.getContractFactory("TestToken")
     testToken = await TestToken.deploy()

--- a/test/RewardsPool.test.js
+++ b/test/RewardsPool.test.js
@@ -17,9 +17,9 @@ describe("RewardsPool", () => {
   let thirdParty
 
   beforeEach(async () => {
-    rewardManager = await ethers.getSigner(1)
-    assetPool = await ethers.getSigner(2)
-    thirdParty = await ethers.getSigner(3)
+    rewardManager = (await ethers.getSigners())[1]
+    assetPool = (await ethers.getSigners())[2]
+    thirdParty = (await ethers.getSigners())[3]
 
     const TestToken = await ethers.getContractFactory("TestToken")
     rewardToken = await TestToken.deploy()

--- a/test/RiskManagerV1.test.js
+++ b/test/RiskManagerV1.test.js
@@ -33,9 +33,9 @@ describe("RiskManagerV1", () => {
   let coveragePoolStub
 
   beforeEach(async () => {
-    owner = await ethers.getSigner(0)
-    notifier = await ethers.getSigner(1)
-    bidder = await ethers.getSigner(2)
+    owner = (await ethers.getSigners())[0]
+    notifier = (await ethers.getSigners())[1]
+    bidder = (await ethers.getSigners())[2]
 
     const TestToken = await ethers.getContractFactory("TestToken")
     tbtcToken = await TestToken.deploy()

--- a/test/SignerBondsManualSwap.test.js
+++ b/test/SignerBondsManualSwap.test.js
@@ -10,8 +10,8 @@ describe("SignerBondsManualSwap", () => {
   let riskManagerV1
 
   beforeEach(async () => {
-    governance = await ethers.getSigner(0)
-    recipient = await ethers.getSigner(1)
+    governance = (await ethers.getSigners())[0]
+    recipient = (await ethers.getSigners())[1]
 
     const SignerBondsManualSwap = await ethers.getContractFactory(
       "SignerBondsManualSwap"

--- a/test/system/deposit-validation.test.js
+++ b/test/system/deposit-validation.test.js
@@ -36,7 +36,7 @@ describeFn("System -- deposit validation", () => {
   before(async () => {
     await resetFork(startingBlock)
 
-    governance = await ethers.getSigner(0)
+    governance = (await ethers.getSigners())[0]
 
     const contracts = await initContracts("SignerBondsManualSwap")
     tbtcToken = contracts.tbtcToken

--- a/test/system/init-contracts.js
+++ b/test/system/init-contracts.js
@@ -27,7 +27,7 @@ function setBondAuctionThreshold(newThreshold) {
 async function initContracts(swapStrategy) {
   const auctionLength = 86400 // 24h
 
-  const rewardsManager = await ethers.getSigner(1)
+  const rewardsManager = (await ethers.getSigners())[1]
 
   const UnderwriterToken = await ethers.getContractFactory("UnderwriterToken")
   const underwriterToken = await UnderwriterToken.deploy(

--- a/test/system/liquidation-multiple-take-offers.test.js
+++ b/test/system/liquidation-multiple-take-offers.test.js
@@ -52,7 +52,7 @@ describeFn("System -- multiple partial fills", () => {
   before(async () => {
     await resetFork(startingBlock)
 
-    governance = await ethers.getSigner(0)
+    governance = (await ethers.getSigners())[0]
     const contracts = await initContracts("SignerBondsManualSwap")
     tbtcToken = contracts.tbtcToken
     collateralToken = contracts.collateralToken

--- a/test/system/liquidation.test.js
+++ b/test/system/liquidation.test.js
@@ -51,7 +51,7 @@ describeFn("System -- liquidation", () => {
   before(async () => {
     await resetFork(startingBlock)
 
-    governance = await ethers.getSigner(0)
+    governance = (await ethers.getSigners())[0]
 
     setBondAuctionThreshold(bondedAmountPercentage)
     const contracts = await initContracts("SignerBondsManualSwap")

--- a/test/system/notifier-rewards.test.js
+++ b/test/system/notifier-rewards.test.js
@@ -39,10 +39,10 @@ describeFn("System -- notifier rewards", () => {
   let rewardsManager
 
   beforeEach(async () => {
-    governance = await ethers.getSigner(0)
-    notifier = await ethers.getSigner(1)
-    otherNotifier = await ethers.getSigner(2)
-    rewardsManager = await ethers.getSigner(3)
+    governance = (await ethers.getSigners())[0]
+    notifier = (await ethers.getSigners())[1]
+    otherNotifier = (await ethers.getSigners())[2]
+    rewardsManager = (await ethers.getSigners())[3]
 
     const TestToken = await ethers.getContractFactory("TestToken")
     tbtcToken = await TestToken.deploy()

--- a/test/system/surplus-for-auction.test.js
+++ b/test/system/surplus-for-auction.test.js
@@ -52,8 +52,8 @@ describeFn("System -- buying a deposit with surplus", () => {
 
   before(async () => {
     await resetFork(startingBlock)
-    governance = await ethers.getSigner(0)
-    rewardsManager = await ethers.getSigner(1)
+    governance = (await ethers.getSigners())[0]
+    rewardsManager = (await ethers.getSigners())[1]
 
     const contracts = await initContracts("SignerBondsManualSwap")
     tbtcToken = contracts.tbtcToken

--- a/test/system/uniswap-v2.test.js
+++ b/test/system/uniswap-v2.test.js
@@ -20,7 +20,7 @@ describeFn("System -- swap signer bonds on UniswapV2", () => {
   before(async () => {
     await resetFork(startingBlock)
 
-    const governance = await ethers.getSigner(0)
+    const governance = (await ethers.getSigners())[0]
 
     const contracts = await initContracts("SignerBondsUniswapV2")
     collateralToken = contracts.collateralToken

--- a/yarn.lock
+++ b/yarn.lock
@@ -881,10 +881,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@nomiclabs/hardhat-ethers@^2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@nomiclabs/hardhat-ethers/-/hardhat-ethers-2.0.2.tgz#c472abcba0c5185aaa4ad4070146e95213c68511"
-  integrity sha512-6quxWe8wwS4X5v3Au8q1jOvXYEPkS1Fh+cME5u6AwNdnI4uERvPlVjlgRWzpnb+Rrt1l/cEqiNRH9GlsBMSDQg==
+"@nomiclabs/hardhat-ethers@npm:hardhat-deploy-ethers":
+  version "0.3.0-beta.10"
+  resolved "https://registry.yarnpkg.com/hardhat-deploy-ethers/-/hardhat-deploy-ethers-0.3.0-beta.10.tgz#bccfcf635d380bbab3638960f6739fe4d396fc5f"
+  integrity sha512-TeyriUshRZ7XVHOjMsDtTozIrdwLf3Bw+oZRYNhXdG/eut5HeDhjUFPfRlG7TI1lSLvkcB5dt7OxOtPYKDOxTg==
 
 "@nomiclabs/hardhat-waffle@^2.0.1":
   version "2.0.1"


### PR DESCRIPTION
The plugin `hardhat-deploy-ethers` from creators of `hardhat-deploy` plugin we use for deployment. The plugin enhances original [@nomiclabs/hardhat-ethers](https://www.npmjs.com/package/@nomiclabs/hardhat-ethers) with additional functionalities that will simplify our code, e.g. `await ethers.getContract("ContractName")` function.

See https://github.com/wighawag/hardhat-deploy-ethers for details.

According to API (https://github.com/wighawag/hardhat-deploy-ethers) `getSigner` expects an address as parameter. To get a signer by index we switched to `getSigners()` function.

Depends on: https://github.com/keep-network/coverage-pools/pull/103