### PR TITLE
Check amount of underwriter tokens that are minted

### DIFF
--- a/contracts/AssetPool.sol
+++ b/contracts/AssetPool.sol
@@ -363,7 +363,7 @@ contract AssetPool is Ownable, IAssetPool {
     }
 
     /// @notice Lets the contract owner to begin an update of withdrawal timeout
-    ///         parmeter value. The withdrawal timeout is the time the
+    ///         parameter value. The withdrawal timeout is the time the
     ///         underwriter has - after the withdrawal delay passed - to
     ///         complete the withdrawal. The change needs to be finalized with
     ///         a call to finalizeWithdrawalTimeoutUpdate after the required

--- a/contracts/AssetPool.sol
+++ b/contracts/AssetPool.sol
@@ -478,7 +478,7 @@ contract AssetPool is Ownable, IAssetPool {
         } else {
             toMint = (amount * covSupply) / collateralBalance;
         }
-        require(toMint > 0, "Minted amount would be 0");
+        require(toMint > 0, "Minted tokens amount must be greater than 0");
 
         underwriterToken.mint(depositor, toMint);
         collateralToken.safeTransferFrom(depositor, address(this), amount);

--- a/contracts/AssetPool.sol
+++ b/contracts/AssetPool.sol
@@ -478,6 +478,8 @@ contract AssetPool is Ownable, IAssetPool {
         } else {
             toMint = (amount * covSupply) / collateralBalance;
         }
+        require(toMint > 0, "Minted amount would be 0");
+
         underwriterToken.mint(depositor, toMint);
         collateralToken.safeTransferFrom(depositor, address(this), amount);
     }

--- a/contracts/CoveragePool.sol
+++ b/contracts/CoveragePool.sol
@@ -148,7 +148,7 @@ contract CoveragePool is Ownable {
     }
 
     /// @notice Lets the governance to begin an update of withdrawal timeout
-    ///         parmeter value. The withdrawal timeout is the time the
+    ///         parameter value. The withdrawal timeout is the time the
     ///         underwriter has - after the withdrawal delay passed - to
     ///         complete the withdrawal. The change needs to be finalized with
     ///         a call to finalizeWithdrawalTimeoutUpdate after the required

--- a/test/AssetPool.test.js
+++ b/test/AssetPool.test.js
@@ -228,28 +228,26 @@ describe("AssetPool", () => {
       })
     })
 
-    context(
-      "when collateral tokens sent to asset pool outside of cov pools",
-      () => {
-        beforeEach(async () => {
-          // Deposit some small amount of collateral tokens so that the amount
-          // of underwriter tokens is not 0
-          await assetPool.connect(underwriter1).deposit(1)
-          // Send collateral tokens to the asset pool outside cov pools
-          await collateralToken
-            .connect(underwriter2)
-            .transfer(assetPool.address, to1e18(10))
-        })
+    context("when minting 0 underwriter tokens", () => {
+      beforeEach(async () => {
+        // Deposit some small amount of collateral tokens so that the amount
+        // of underwriter tokens is not 0
+        await assetPool.connect(underwriter1).deposit(1)
+        // Send collateral tokens to the asset pool directly, without minting
+        // underwriter tokens
+        await collateralToken
+          .connect(underwriter2)
+          .transfer(assetPool.address, to1e18(10))
+      })
 
-        it("should revert", async () => {
-          // Reverts if amount deposited * total underwriter supply < collateral
-          // balance of asset pool
-          await expect(
-            assetPool.connect(underwriter1).deposit(to1e18(10))
-          ).to.be.revertedWith("Minted tokens amount must be greater than 0")
-        })
-      }
-    )
+      it("should revert", async () => {
+        // Reverts if amount deposited * total underwriter supply < collateral
+        // balance of asset pool
+        await expect(
+          assetPool.connect(underwriter1).deposit(to1e18(10))
+        ).to.be.revertedWith("Minted tokens amount must be greater than 0")
+      })
+    })
   })
 
   describe("receiveApproval", () => {

--- a/test/AssetPool.test.js
+++ b/test/AssetPool.test.js
@@ -246,7 +246,7 @@ describe("AssetPool", () => {
           // balance of asset pool
           await expect(
             assetPool.connect(underwriter1).deposit(to1e18(10))
-          ).to.be.revertedWith("Minted amount would be 0")
+          ).to.be.revertedWith("Minted tokens amount must be greater than 0")
         })
       }
     )

--- a/test/AssetPool.test.js
+++ b/test/AssetPool.test.js
@@ -227,6 +227,29 @@ describe("AssetPool", () => {
         ).to.be.closeTo("45454545454545454545", assertionPrecision)
       })
     })
+
+    context(
+      "when collateral tokens sent to asset pool outside of cov pools",
+      () => {
+        beforeEach(async () => {
+          // Deposit some small amount of collateral tokens so that the amount
+          // of underwriter tokens is not 0
+          await assetPool.connect(underwriter1).deposit(1)
+          // Send collateral tokens to the asset pool outside cov pools
+          await collateralToken
+            .connect(underwriter2)
+            .transfer(assetPool.address, to1e18(10))
+        })
+
+        it("should revert", async () => {
+          // Reverts if amount deposited * total underwriter supply < collateral
+          // balance of asset pool
+          await expect(
+            assetPool.connect(underwriter1).deposit(to1e18(10))
+          ).to.be.revertedWith("Minted amount would be 0")
+        })
+      }
+    )
   })
 
   describe("receiveApproval", () => {


### PR DESCRIPTION
This PR adds a check for the amount of minted underwriter tokens when collateral tokens are deposited so that the `deposit` transaction reverts if the amount of COV to mint is zero.

The check can fail in the following scenario:
1) deposit a small amount of collateral tokens (so that the supply of underwriter tokens is at least `1`)
2) send (not deposit) a bigger amount of collateral tokens to the asset pool
3) deposit less collateral tokens that sent to the contract in the previous step

Closes https://github.com/keep-network/coverage-pools/issues/133.