### PR TITLE
Approving and unapproving signer bonds swappers

### DIFF
--- a/contracts/SignerBondsUniswapV2.sol
+++ b/contracts/SignerBondsUniswapV2.sol
@@ -77,6 +77,9 @@ contract SignerBondsUniswapV2 is ISignerBondsSwapStrategy, Ownable {
     address public immutable assetPool;
     address public immutable collateralToken;
 
+    // Currently approved operators that can swap signer bonds on Uniswap V2
+    mapping(address => bool) public approvedOperators;
+
     // Determines the maximum allowed price impact for the swap transaction.
     // If transaction's price impact is higher, transaction will be reverted.
     // Default value is 100 basis points (1%).
@@ -93,7 +96,22 @@ contract SignerBondsUniswapV2 is ISignerBondsSwapStrategy, Ownable {
     // If false, open auctions are not taken into account.
     bool public revertIfAuctionOpen = true;
 
+    event SignerBondsSwapOperatorApproved(address operator, uint256 timestamp);
+    event SignerBondsSwapOperatorUnapproved(
+        address operator,
+        uint256 timestamp
+    );
     event UniswapV2SwapExecuted(uint256[] amounts);
+
+    /// @notice Reverts if called by a signer bonds swap operator that is not
+    ///         approved
+    modifier onlyApprovedOperator() {
+        require(
+            approvedOperators[msg.sender],
+            "Signer bonds swap operator not approved"
+        );
+        _;
+    }
 
     constructor(IUniswapV2Router _uniswapRouter, CoveragePool _coveragePool) {
         uniswapRouter = _uniswapRouter;
@@ -194,7 +212,7 @@ contract SignerBondsUniswapV2 is ISignerBondsSwapStrategy, Ownable {
     function swapSignerBondsOnUniswapV2(
         IRiskManagerV1 riskManager,
         uint256 amount
-    ) external {
+    ) external onlyApprovedOperator {
         require(amount > 0, "Amount must be greater than 0");
         require(
             amount <= address(riskManager).balance,
@@ -239,6 +257,30 @@ contract SignerBondsUniswapV2 is ISignerBondsSwapStrategy, Ownable {
             );
 
         emit UniswapV2SwapExecuted(amounts);
+    }
+
+    /// @notice Approves the signer bonds swap operator. The change takes effect
+    ///         immediately.
+    /// @dev Can be called only by the contract owner.
+    /// @param operator Operator that will be approved
+    function approveOperator(address operator) external onlyOwner {
+        /* solhint-disable-next-line not-rely-on-time */
+        emit SignerBondsSwapOperatorApproved(operator, block.timestamp);
+        approvedOperators[operator] = true;
+    }
+
+    /// @notice Unapproves the signer bonds swap Operator. The change takes
+    ///         effect immediately.
+    /// @dev Can be called only by the contract owner.
+    /// @param operator Operator that will be unapproved
+    function unapproveOperator(address operator) external onlyOwner {
+        require(
+            approvedOperators[operator],
+            "Signer swap operator is not approved"
+        );
+        /* solhint-disable-next-line not-rely-on-time */
+        emit SignerBondsSwapOperatorUnapproved(operator, block.timestamp);
+        delete approvedOperators[operator];
     }
 
     /// @notice Checks the price impact of buying a given amount of tokens

--- a/contracts/SignerBondsUniswapV2.sol
+++ b/contracts/SignerBondsUniswapV2.sol
@@ -268,7 +268,10 @@ contract SignerBondsUniswapV2 is ISignerBondsSwapStrategy, Ownable {
     /// @dev Can be called only by the contract owner.
     /// @param swapper Swapper that will be unapproved
     function unapproveSwapper(address swapper) external onlyOwner {
-        require(approvedSwappers[swapper], "Signer swapper is not approved");
+        require(
+            approvedSwappers[swapper],
+            "Signer bonds swapper is not approved"
+        );
         emit SignerBondsSwapperUnapproved(swapper);
         delete approvedSwappers[swapper];
     }

--- a/test/SignerBondsUniswapV2.test.js
+++ b/test/SignerBondsUniswapV2.test.js
@@ -98,7 +98,7 @@ describe("SignerBondsUniswapV2", () => {
           .be.true
       })
 
-      it("should emit RiskManagerUnapproved event", async () => {
+      it("should emit SignerBondsSwapperApproved event", async () => {
         await expect(tx)
           .to.emit(signerBondsUniswapV2, "SignerBondsSwapperApproved")
           .withArgs(swapper.address)
@@ -123,7 +123,7 @@ describe("SignerBondsUniswapV2", () => {
           signerBondsUniswapV2
             .connect(governance)
             .unapproveSwapper(swapper.address)
-        ).to.be.revertedWith("Signer swapper is not approved")
+        ).to.be.revertedWith("Signer bonds swapper is not approved")
       })
     })
 
@@ -144,7 +144,7 @@ describe("SignerBondsUniswapV2", () => {
           .be.false
       })
 
-      it("should emit RiskManagerUnapproved event", async () => {
+      it("should emit SignerBondsSwapperUnapproved event", async () => {
         await expect(tx)
           .to.emit(signerBondsUniswapV2, "SignerBondsSwapperUnapproved")
           .withArgs(swapper.address)

--- a/test/SignerBondsUniswapV2.test.js
+++ b/test/SignerBondsUniswapV2.test.js
@@ -157,7 +157,7 @@ describe("SignerBondsUniswapV2", () => {
       it("should revert", async () => {
         await expect(
           signerBondsUniswapV2
-            .connect(swapper)
+            .connect(thirdParty)
             .swapSignerBondsOnUniswapV2(riskManagerV1.address, 123)
         ).to.be.revertedWith("Signer bonds swapper not approved")
       })

--- a/test/SignerBondsUniswapV2.test.js
+++ b/test/SignerBondsUniswapV2.test.js
@@ -1,0 +1,166 @@
+const { expect } = require("chai")
+
+describe("SignerBondsUniswapV2", () => {
+  let governance
+  let thirdParty
+  let rewardsManager
+  let swapper
+  let riskManagerV1
+  let signerBondsUniswapV2
+
+  beforeEach(async () => {
+    governance = await ethers.getSigner(0)
+    thirdParty = await ethers.getSigner(1)
+    rewardsManager = await ethers.getSigner(2)
+    swapper = await ethers.getSigner(3)
+
+    const UniswapV2RouterStub = await ethers.getContractFactory(
+      "UniswapV2RouterStub"
+    )
+    const uniswapV2RouterStub = await UniswapV2RouterStub.deploy()
+    await uniswapV2RouterStub.deployed()
+
+    const TestToken = await ethers.getContractFactory("TestToken")
+    const testToken = await TestToken.deploy()
+    await testToken.deployed()
+
+    const UnderwriterToken = await ethers.getContractFactory("UnderwriterToken")
+    const underwriterToken = await UnderwriterToken.deploy(
+      "Underwriter Token",
+      "COV"
+    )
+    await underwriterToken.deployed()
+
+    const AssetPool = await ethers.getContractFactory("AssetPool")
+    const assetPool = await AssetPool.deploy(
+      testToken.address,
+      underwriterToken.address,
+      rewardsManager.address
+    )
+    await assetPool.deployed()
+
+    const CoveragePool = await ethers.getContractFactory("CoveragePool")
+    const coveragePool = await CoveragePool.deploy(assetPool.address)
+    await coveragePool.deployed()
+
+    const SignerBondsUniswapV2 = await ethers.getContractFactory(
+      "SignerBondsUniswapV2"
+    )
+
+    signerBondsUniswapV2 = await SignerBondsUniswapV2.deploy(
+      uniswapV2RouterStub.address,
+      coveragePool.address
+    )
+    await signerBondsUniswapV2.deployed()
+
+    const fakeAddress = "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    const RiskManagerV1Stub = await ethers.getContractFactory(
+      "RiskManagerV1Stub"
+    )
+    riskManagerV1 = await RiskManagerV1Stub.deploy(
+      fakeAddress,
+      fakeAddress,
+      fakeAddress,
+      signerBondsUniswapV2.address,
+      fakeAddress,
+      86400,
+      75
+    )
+    await riskManagerV1.deployed()
+
+    await governance.sendTransaction({
+      to: riskManagerV1.address,
+      value: ethers.utils.parseEther("20"),
+    })
+  })
+
+  describe("approveOperator", () => {
+    context("when caller is not the governance", () => {
+      it("should revert", async () => {
+        await expect(
+          signerBondsUniswapV2
+            .connect(thirdParty)
+            .approveSwapper(swapper.address)
+        ).to.be.revertedWith("Ownable: caller is not the owner")
+      })
+    })
+
+    context("when caller is the governance", () => {
+      let tx
+      beforeEach(async () => {
+        tx = await signerBondsUniswapV2
+          .connect(governance)
+          .approveSwapper(swapper.address)
+      })
+
+      it("should approve the swapper", async () => {
+        expect(await signerBondsUniswapV2.approvedSwappers(swapper.address)).to
+          .be.true
+      })
+
+      it("should emit RiskManagerUnapproved event", async () => {
+        await expect(tx)
+          .to.emit(signerBondsUniswapV2, "SignerBondsSwapperApproved")
+          .withArgs(swapper.address)
+      })
+    })
+  })
+
+  describe("unapproveOperator", () => {
+    context("when caller is not the governance", () => {
+      it("should revert", async () => {
+        await expect(
+          signerBondsUniswapV2
+            .connect(thirdParty)
+            .unapproveSwapper(swapper.address)
+        ).to.be.revertedWith("Ownable: caller is not the owner")
+      })
+    })
+
+    context("when swapper is not approved", () => {
+      it("should revert", async () => {
+        await expect(
+          signerBondsUniswapV2
+            .connect(governance)
+            .unapproveSwapper(swapper.address)
+        ).to.be.revertedWith("Signer swapper is not approved")
+      })
+    })
+
+    context("when caller is governance and swapper approved", () => {
+      let tx
+      beforeEach(async () => {
+        await signerBondsUniswapV2
+          .connect(governance)
+          .approveSwapper(swapper.address)
+
+        tx = await signerBondsUniswapV2
+          .connect(governance)
+          .unapproveSwapper(swapper.address)
+      })
+
+      it("should unapprove the swapper", async () => {
+        expect(await signerBondsUniswapV2.approvedSwappers(swapper.address)).to
+          .be.false
+      })
+
+      it("should emit RiskManagerUnapproved event", async () => {
+        await expect(tx)
+          .to.emit(signerBondsUniswapV2, "SignerBondsSwapperUnapproved")
+          .withArgs(swapper.address)
+      })
+    })
+  })
+
+  describe("swapSignerBondsOnUniswapV2", () => {
+    context("when swapper is not approved", () => {
+      it("should revert", async () => {
+        await expect(
+          signerBondsUniswapV2
+            .connect(swapper)
+            .swapSignerBondsOnUniswapV2(riskManagerV1.address, 123)
+        ).to.be.revertedWith("Signer bonds swapper not approved")
+      })
+    })
+  })
+})

--- a/test/SignerBondsUniswapV2.test.js
+++ b/test/SignerBondsUniswapV2.test.js
@@ -74,7 +74,7 @@ describe("SignerBondsUniswapV2", () => {
     })
   })
 
-  describe("approveOperator", () => {
+  describe("approveSwapper", () => {
     context("when caller is not the governance", () => {
       it("should revert", async () => {
         await expect(
@@ -106,7 +106,7 @@ describe("SignerBondsUniswapV2", () => {
     })
   })
 
-  describe("unapproveOperator", () => {
+  describe("unapproveSwapper", () => {
     context("when caller is not the governance", () => {
       it("should revert", async () => {
         await expect(

--- a/test/system/uniswap-v2.test.js
+++ b/test/system/uniswap-v2.test.js
@@ -14,7 +14,7 @@ describeFn("System -- swap signer bonds on UniswapV2", () => {
   let assetPool
   let coveragePool
   let signerBondsUniswapV2
-  let signerBondsSwapOperator
+  let swapper
   let riskManagerV1
 
   before(async () => {
@@ -28,7 +28,7 @@ describeFn("System -- swap signer bonds on UniswapV2", () => {
     assetPool = contracts.assetPool
     coveragePool = contracts.coveragePool
     signerBondsUniswapV2 = contracts.signerBondsSwapStrategy
-    signerBondsSwapOperator = contracts.thirdPartyAccount
+    swapper = contracts.thirdPartyAccount
     riskManagerV1 = contracts.riskManagerV1
 
     await underwriterToken
@@ -60,35 +60,16 @@ describeFn("System -- swap signer bonds on UniswapV2", () => {
         expect(balance).to.equal(ethers.utils.parseEther("20"))
       })
     })
-
-    describe("signer bonds uniswap v2", () => {
-      context("when swap operator is not approved", () => {
-        it("should revert", async () => {
-          await expect(
-            signerBondsUniswapV2
-              .connect(signerBondsSwapOperator)
-              .swapSignerBondsOnUniswapV2(
-                riskManagerV1.address,
-                ethers.utils.parseEther("10"),
-                {
-                  gasLimit: 210000,
-                }
-              )
-          ).to.be.revertedWith("Signer bonds swap operator not approved")
-        })
-      })
-    })
   })
 
   describe("when signer bonds are swapped on UniswapV2", () => {
     let tx
-
     before(async () => {
       await signerBondsUniswapV2
         .connect(governance)
-        .approveOperator(signerBondsSwapOperator.address)
+        .approveSwapper(swapper.address)
       tx = await signerBondsUniswapV2
-        .connect(signerBondsSwapOperator)
+        .connect(swapper)
         .swapSignerBondsOnUniswapV2(
           riskManagerV1.address,
           ethers.utils.parseEther("10"),


### PR DESCRIPTION
This PR adds functionalities for `approving` and `unapproving` operators that can swap signer bonds on `Uniswap V2`.
Closes https://github.com/keep-network/coverage-pools/issues/135.