### PR TITLE
Use solhint-config-keep in version 0.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prettier": "^2.2.1",
     "prettier-plugin-solidity": "^1.0.0-beta.2 ",
     "solhint": "^3.3.4",
-    "solhint-config-keep": "github:keep-network/solhint-config-keep",
+    "solhint-config-keep": "github:keep-network/solhint-config-keep#0.1.0",
     "solidity-coverage": "^0.7.16",
     "typescript": "^3.7.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8104,7 +8104,7 @@ solc@^0.6.3:
     semver "^5.5.0"
     tmp "0.0.33"
 
-"solhint-config-keep@github:keep-network/solhint-config-keep":
+"solhint-config-keep@github:keep-network/solhint-config-keep#0.1.0":
   version "0.1.0"
   resolved "https://codeload.github.com/keep-network/solhint-config-keep/tar.gz/5e1751e58c0f1c507305ffc8c7f6c58047657ada"
 


### PR DESCRIPTION
This PR makes sure that the version `0.1.0` of `solhint-config-keep` is used in `Coverage Pools`.
This should eliminate the problem of `solhint-config-keep` being not up-to-date locally.

Calling `yarn install` locally may be necessary to force the installation of the version of `solhint-config-keep` tagged as [0.1.0](https://github.com/keep-network/solhint-config-keep/releases/tag/0.1.0).