### PR TITLE
Follow-up for deployment script

### DIFF
--- a/deploy/05_deploy_asset_pool.js
+++ b/deploy/05_deploy_asset_pool.js
@@ -15,6 +15,12 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
 
   const rewardsPoolAddress = await read("AssetPool", "rewardsPool")
 
+  if (
+    ethers.utils.getAddress(rewardsPoolAddress) === ethers.constants.AddressZero
+  ) {
+    throw new Error(`RewardsPool address is a zero address`)
+  }
+
   // The`RewardsPool` contract is created in the `AssetPool` constructor so
   // we create an artifact for it.
   const receipt = AssetPool.receipt

--- a/deploy/05_deploy_asset_pool.js
+++ b/deploy/05_deploy_asset_pool.js
@@ -1,5 +1,5 @@
 module.exports = async ({ getNamedAccounts, deployments }) => {
-  const { deploy, getArtifact, log, save } = deployments
+  const { deploy, getArtifact, read, log, save } = deployments
   const { deployer, rewardManager } = await getNamedAccounts()
 
   const KeepToken = await deployments.get("KeepToken")
@@ -13,8 +13,7 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
     log: true,
   })
 
-  const assetPool = await ethers.getContractAt("AssetPool", AssetPool.address)
-  const rewardsPoolAddress = await assetPool.rewardsPool()
+  const rewardsPoolAddress = await read("AssetPool", "rewardsPool")
 
   // The`RewardsPool` contract is created in the `AssetPool` constructor so
   // we create an artifact for it.

--- a/deploy/06_deploy_coverage_pool.js
+++ b/deploy/06_deploy_coverage_pool.js
@@ -9,7 +9,10 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
     log: true,
   })
 
-  if ((await read("AssetPool", "owner")) !== CoveragePool.address) {
+  if (
+    ethers.utils.getAddress(await read("AssetPool", "owner")) !==
+    ethers.utils.getAddress(CoveragePool.address)
+  ) {
     log(`transferring ownership of AssetPool to ${CoveragePool.address}`)
 
     await execute(
@@ -20,7 +23,10 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
     )
   }
 
-  if ((await read("UnderwriterToken", "owner")) !== AssetPool.address) {
+  if (
+    ethers.utils.getAddress(await read("UnderwriterToken", "owner")) !==
+    ethers.utils.getAddress(AssetPool.address)
+  ) {
     log(`transferring ownership of UnderwriterToken to ${AssetPool.address}`)
 
     await execute(

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -9,7 +9,7 @@ DONE_END='\n\n\e[0m'    # new line + reset
 COVERAGE_POOL_PATH=$(realpath $(dirname $0)/../)
 
 # Defaults, can be overwritten by env variables/input parameters
-NETWORK_DEFAULT="local"
+NETWORK_DEFAULT="development"
 KEEP_TOKEN_ADDRESS=${KEEP_TOKEN_ADDRESS:-""}
 TBTC_TOKEN_ADDRESS=${TBTC_TOKEN_ADDRESS:-""}
 TBTC_DEPOSIT_TOKEN_ADDRESS=${TBTC_DEPOSIT_TOKEN_ADDRESS:-""}


### PR DESCRIPTION
We want to compare addresses securely by converting them to consistently formatted addresses.

We renamed the default network from `local` to `development` and missed to update `install.sh` script.