### PR TITLE
Unit tests for uniswap strategy

### DIFF
--- a/test/SignerBondsUniswapV2.test.js
+++ b/test/SignerBondsUniswapV2.test.js
@@ -74,6 +74,181 @@ describe("SignerBondsUniswapV2", () => {
     })
   })
 
+  describe("setMaxAllowedPriceImpact", () => {
+    const maxAllowedPriceImpact = 10000
+
+    context("when caller is not the governance", () => {
+      it("should revert", async () => {
+        await expect(
+          signerBondsUniswapV2
+            .connect(thirdParty)
+            .setMaxAllowedPriceImpact(maxAllowedPriceImpact)
+        ).to.be.revertedWith("Ownable: caller is not the owner")
+      })
+    })
+
+    context("when max allowed price impact too big", () => {
+      it("should revert", async () => {
+        await expect(
+          signerBondsUniswapV2
+            .connect(governance)
+            .setMaxAllowedPriceImpact(maxAllowedPriceImpact + 1)
+        ).to.be.revertedWith("Maximum value is 10000 basis points")
+      })
+    })
+
+    context("when governance did not set max allowed price impact", () => {
+      const defaultPriceImpact = 100
+      it("should return the default value", async () => {
+        expect(await signerBondsUniswapV2.maxAllowedPriceImpact()).to.be.equal(
+          defaultPriceImpact
+        )
+      })
+    })
+
+    context("when max allowed price impact is in correct range", () => {
+      const priceImpact = 500
+      beforeEach(async () => {
+        expect(
+          await signerBondsUniswapV2
+            .connect(governance)
+            .setMaxAllowedPriceImpact(priceImpact)
+        )
+      })
+
+      it("should set max allowed price impact", async () => {
+        expect(await signerBondsUniswapV2.maxAllowedPriceImpact()).to.be.equal(
+          priceImpact
+        )
+      })
+    })
+  })
+
+  describe("setSlippageTolerance", () => {
+    const maxBasisPoints = 10000
+
+    context("when caller is not the governance", () => {
+      it("should revert", async () => {
+        await expect(
+          signerBondsUniswapV2
+            .connect(thirdParty)
+            .setSlippageTolerance(maxBasisPoints)
+        ).to.be.revertedWith("Ownable: caller is not the owner")
+      })
+    })
+
+    context("when slippage tolerance too big", () => {
+      it("should revert", async () => {
+        await expect(
+          signerBondsUniswapV2
+            .connect(governance)
+            .setSlippageTolerance(maxBasisPoints + 1)
+        ).to.be.revertedWith("Maximum value is 10000 basis points")
+      })
+    })
+
+    context("when governance did not set slippage tolerance", () => {
+      const defaultSlippageTolerance = 50
+      it("should return the default value", async () => {
+        expect(await signerBondsUniswapV2.slippageTolerance()).to.be.equal(
+          defaultSlippageTolerance
+        )
+      })
+    })
+
+    context("when slippage tolerance is in correct range", () => {
+      const priceImpact = 500
+      beforeEach(async () => {
+        expect(
+          await signerBondsUniswapV2
+            .connect(governance)
+            .setSlippageTolerance(priceImpact)
+        )
+      })
+
+      it("should set slippage tolerance", async () => {
+        expect(await signerBondsUniswapV2.slippageTolerance()).to.be.equal(
+          priceImpact
+        )
+      })
+    })
+  })
+
+  describe("setSwapDeadline", () => {
+    context("when caller is not the governance", () => {
+      it("should revert", async () => {
+        await expect(
+          signerBondsUniswapV2.connect(thirdParty).setSwapDeadline(10 * 60) // 10 min
+        ).to.be.revertedWith("Ownable: caller is not the owner")
+      })
+    })
+
+    context("when governance did not set default swap deadline", () => {
+      const defaultSwapDeadline = 20 * 60 // 20 min
+      it("should return the default value", async () => {
+        expect(await signerBondsUniswapV2.swapDeadline()).to.be.equal(
+          defaultSwapDeadline
+        )
+      })
+    })
+
+    context("when governance set default swap deadline", () => {
+      const swapDeadline = 100 * 60 // 100 min
+      beforeEach(async () => {
+        expect(
+          await signerBondsUniswapV2
+            .connect(governance)
+            .setSwapDeadline(swapDeadline)
+        )
+      })
+
+      it("should set swap deadline", async () => {
+        expect(await signerBondsUniswapV2.swapDeadline()).to.be.equal(
+          swapDeadline
+        )
+      })
+    })
+  })
+
+  describe("setRevertIfAuctionOpen", () => {
+    context("when caller is not the governance", () => {
+      it("should revert", async () => {
+        await expect(
+          signerBondsUniswapV2.connect(thirdParty).setRevertIfAuctionOpen(false)
+        ).to.be.revertedWith("Ownable: caller is not the owner")
+      })
+    })
+
+    context(
+      "when governance did not set default value for revert if auction open",
+      () => {
+        const defaultRevertIfAuctionOpen = true
+        it("should return the default value", async () => {
+          expect(await signerBondsUniswapV2.revertIfAuctionOpen()).to.be.equal(
+            defaultRevertIfAuctionOpen
+          )
+        })
+      }
+    )
+
+    context("when governance  set revert if auction open", () => {
+      const revertIfAuctionOpen = false
+      beforeEach(async () => {
+        expect(
+          await signerBondsUniswapV2
+            .connect(governance)
+            .setRevertIfAuctionOpen(revertIfAuctionOpen)
+        )
+      })
+
+      it("should set revert if auction open", async () => {
+        expect(await signerBondsUniswapV2.revertIfAuctionOpen()).to.be.equal(
+          revertIfAuctionOpen
+        )
+      })
+    })
+  })
+
   describe("approveSwapper", () => {
     context("when caller is not the governance", () => {
       it("should revert", async () => {

--- a/test/SignerBondsUniswapV2.test.js
+++ b/test/SignerBondsUniswapV2.test.js
@@ -87,7 +87,7 @@ describe("SignerBondsUniswapV2", () => {
       })
     })
 
-    context("when max allowed price impact too big", () => {
+    context("when max allowed price impact too high", () => {
       it("should revert", async () => {
         await expect(
           signerBondsUniswapV2
@@ -137,7 +137,7 @@ describe("SignerBondsUniswapV2", () => {
       })
     })
 
-    context("when slippage tolerance too big", () => {
+    context("when slippage tolerance too high", () => {
       it("should revert", async () => {
         await expect(
           signerBondsUniswapV2
@@ -220,7 +220,7 @@ describe("SignerBondsUniswapV2", () => {
     })
 
     context(
-      "when governance did not set default value for revert if auction open",
+      "when governance did not set default value for the revert if auction open flag",
       () => {
         const defaultRevertIfAuctionOpen = true
         it("should return the default value", async () => {
@@ -231,7 +231,7 @@ describe("SignerBondsUniswapV2", () => {
       }
     )
 
-    context("when governance  set revert if auction open", () => {
+    context("when governance sets revert flag on opened auction", () => {
       const revertIfAuctionOpen = false
       beforeEach(async () => {
         expect(
@@ -241,7 +241,7 @@ describe("SignerBondsUniswapV2", () => {
         )
       })
 
-      it("should set revert if auction open", async () => {
+      it("should set the revert flag to false", async () => {
         expect(await signerBondsUniswapV2.revertIfAuctionOpen()).to.be.equal(
           revertIfAuctionOpen
         )

--- a/test/SignerBondsUniswapV2.test.js
+++ b/test/SignerBondsUniswapV2.test.js
@@ -74,6 +74,17 @@ describe("SignerBondsUniswapV2", () => {
     })
   })
 
+  describe("maxAllowedPriceImpact", () => {
+    context("when governance did not set max allowed price impact", () => {
+      const defaultPriceImpact = 100
+      it("should return the default value", async () => {
+        expect(await signerBondsUniswapV2.maxAllowedPriceImpact()).to.be.equal(
+          defaultPriceImpact
+        )
+      })
+    })
+  })
+
   describe("setMaxAllowedPriceImpact", () => {
     const maxAllowedPriceImpact = 10000
 
@@ -97,15 +108,6 @@ describe("SignerBondsUniswapV2", () => {
       })
     })
 
-    context("when governance did not set max allowed price impact", () => {
-      const defaultPriceImpact = 100
-      it("should return the default value", async () => {
-        expect(await signerBondsUniswapV2.maxAllowedPriceImpact()).to.be.equal(
-          defaultPriceImpact
-        )
-      })
-    })
-
     context("when max allowed price impact is in correct range", () => {
       const priceImpact = 500
       beforeEach(async () => {
@@ -119,6 +121,17 @@ describe("SignerBondsUniswapV2", () => {
       it("should set max allowed price impact", async () => {
         expect(await signerBondsUniswapV2.maxAllowedPriceImpact()).to.be.equal(
           priceImpact
+        )
+      })
+    })
+  })
+
+  describe("slippageTolerance", () => {
+    context("when governance did not set slippage tolerance", () => {
+      const defaultSlippageTolerance = 50
+      it("should return the default value", async () => {
+        expect(await signerBondsUniswapV2.slippageTolerance()).to.be.equal(
+          defaultSlippageTolerance
         )
       })
     })
@@ -147,15 +160,6 @@ describe("SignerBondsUniswapV2", () => {
       })
     })
 
-    context("when governance did not set slippage tolerance", () => {
-      const defaultSlippageTolerance = 50
-      it("should return the default value", async () => {
-        expect(await signerBondsUniswapV2.slippageTolerance()).to.be.equal(
-          defaultSlippageTolerance
-        )
-      })
-    })
-
     context("when slippage tolerance is in correct range", () => {
       const priceImpact = 500
       beforeEach(async () => {
@@ -174,21 +178,23 @@ describe("SignerBondsUniswapV2", () => {
     })
   })
 
-  describe("setSwapDeadline", () => {
-    context("when caller is not the governance", () => {
-      it("should revert", async () => {
-        await expect(
-          signerBondsUniswapV2.connect(thirdParty).setSwapDeadline(10 * 60) // 10 min
-        ).to.be.revertedWith("Ownable: caller is not the owner")
-      })
-    })
-
+  describe("swapDeadline", () => {
     context("when governance did not set default swap deadline", () => {
       const defaultSwapDeadline = 20 * 60 // 20 min
       it("should return the default value", async () => {
         expect(await signerBondsUniswapV2.swapDeadline()).to.be.equal(
           defaultSwapDeadline
         )
+      })
+    })
+  })
+
+  describe("setSwapDeadline", () => {
+    context("when caller is not the governance", () => {
+      it("should revert", async () => {
+        await expect(
+          signerBondsUniswapV2.connect(thirdParty).setSwapDeadline(10 * 60) // 10 min
+        ).to.be.revertedWith("Ownable: caller is not the owner")
       })
     })
 
@@ -210,17 +216,9 @@ describe("SignerBondsUniswapV2", () => {
     })
   })
 
-  describe("setRevertIfAuctionOpen", () => {
-    context("when caller is not the governance", () => {
-      it("should revert", async () => {
-        await expect(
-          signerBondsUniswapV2.connect(thirdParty).setRevertIfAuctionOpen(false)
-        ).to.be.revertedWith("Ownable: caller is not the owner")
-      })
-    })
-
+  describe("revertIfAuctionOpen", () => {
     context(
-      "when governance did not set default value for the revert if auction open flag",
+      "when governance did not set value for the revert if auction open flag",
       () => {
         const defaultRevertIfAuctionOpen = true
         it("should return the default value", async () => {
@@ -230,6 +228,16 @@ describe("SignerBondsUniswapV2", () => {
         })
       }
     )
+  })
+
+  describe("setRevertIfAuctionOpen", () => {
+    context("when caller is not the governance", () => {
+      it("should revert", async () => {
+        await expect(
+          signerBondsUniswapV2.connect(thirdParty).setRevertIfAuctionOpen(false)
+        ).to.be.revertedWith("Ownable: caller is not the owner")
+      })
+    })
 
     context("when governance sets revert flag on opened auction", () => {
       const revertIfAuctionOpen = false


### PR DESCRIPTION
Depends on https://github.com/keep-network/coverage-pools/pull/148
This PR contains unit tests for contract `SignerBondsUniswapV2` for functions that were not tested in system tests.