### PR TITLE
Stop using pretty-format-json pre-commit-hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,8 +3,6 @@ repos:
     rev: v1.3.0
     hooks:
       - id: check-added-large-files
-      - id: pretty-format-json
-        args: ["--autofix", "--no-sort-keys"]
   - repo: local
     hooks:
       - id: lint-js


### PR DESCRIPTION
We don't need to use pretty-format-json as we use prettier to format our code. Prettier takes care of `json` files formatting. The rules enforced by these two sometimes are inconsistent.

This PR is a follow-up from https://github.com/keep-network/coverage-pools/pull/154.