### PR TITLE
Update references to hardhat config after switching from JS to TS

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Install Solidity
         env:
-          SOLC_VERSION: 0.7.6 # according to solidity.version in hardhat.config.js
+          SOLC_VERSION: 0.7.6 # according to solidity.version in hardhat.config.ts
         run: |
           pip3 install solc-select
           solc-select install $SOLC_VERSION

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -81,7 +81,7 @@ file:
 
 Keep in mind that solc version should be the same as the version used internally
 by Hardhat (`solidity.version` property defined in
-https://github.com/keep-network/coverage-pools/blob/main/hardhat.config.js[`hardhat.config.js`]).
+https://github.com/keep-network/coverage-pools/blob/main/hardhat.config.ts[`hardhat.config.ts`]).
 This way Slither will use the same version as used during the contract
 compilation process and avoid errors while performing the analysis.
 

--- a/README.adoc
+++ b/README.adoc
@@ -164,7 +164,7 @@ Example:
 yarn add @keep-network/keep-core@1.8.0-dev
 ```
 
-2. Add an entry in `hardhat.config.js` under `external` property.
+2. Add an entry in `hardhat.config.ts` under `external` property.
 +
 Example:
 +
@@ -210,7 +210,7 @@ Example:
 }
 ```
 
-3. Make sure the directory path is listed in `hardhat.config.js` under
+3. Make sure the directory path is listed in `hardhat.config.ts` under
 `external.deployments.<network>` property.
 +
 Example:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -22,7 +22,7 @@ help() {
 
   echo -e "\nCommand line arguments:\n"
   echo -e "\t--network: Ethereum network." \
-    "Available networks and settings are specified in 'hardhat.config.js'"
+    "Available networks and settings are specified in 'hardhat.config.ts'"
   exit 1 # Exit script after printing help
 }
 


### PR DESCRIPTION
We're no longer storing the hardhat config in JavaScript format. Instead
we're using TypeScript. We need to change references to the config from
`hardhat.config.js` to `hardhat.config.ts`.