### PR TITLE
Solidity version cleanup

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Install Solidity
         env:
-          SOLC_VERSION: 0.7.6 # according to solidity.version in hardhat.config.ts
+          SOLC_VERSION: 0.8.4 # according to solidity.version in hardhat.config.ts
         run: |
           pip3 install solc-select
           solc-select install $SOLC_VERSION

--- a/contracts/GovernanceUtils.sol
+++ b/contracts/GovernanceUtils.sol
@@ -12,7 +12,7 @@
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity <0.9.0;
+pragma solidity 0.8.4;
 
 library GovernanceUtils {
     /// @notice Gets the time remaining until the governable parameter update


### PR DESCRIPTION
Two small cleanup changes:

- Use 0.8.4 solc version for contracts workflow: we changed the solidity version in all files to 0.8.4, th same version is referenced in hardhat.config.js
- 0.8.4 solidity pragma used for GovernanceUtils: This was the last file in which the solidity version was not pinned to
0.8.4. Looks that we mistakenly omitted it.