### PR TITLE
Update custom actions paths after moving actions to `ci`

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Load environment variables
-        uses: keep-network/load-env-variables@v1
+        uses: keep-network/ci/actions/load-env-variables@move-actions-to-ci # TODO: change to @v1 before merging to main
         with:
           environment: ${{ github.event.inputs.environment }}
 
@@ -81,7 +81,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Get upstream packages' versions
-        uses: keep-network/upstream-builds-query@v1
+        uses: keep-network/ci/actions/upstream-builds-query@move-actions-to-ci # TODO: change to @v1 before merging to main
         id: upstream-builds-query
         with:
           upstream-builds: ${{ github.event.inputs.upstream_builds }}
@@ -125,7 +125,7 @@ jobs:
           npm publish --access=public --dry-run
 
       - name: Notify CI about completion of the workflow
-        uses: keep-network/notify-workflow-completed@v1
+        uses: keep-network/ci/actions/notify-workflow-completed@move-actions-to-ci # TODO: change to @v1 before merging to main
         env:
           GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Load environment variables
-        uses: keep-network/ci/actions/load-env-variables@move-actions-to-ci # TODO: change to @v1 before merging to main
+        uses: keep-network/ci/actions/load-env-variables@v1
         with:
           environment: ${{ github.event.inputs.environment }}
 
@@ -81,7 +81,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Get upstream packages' versions
-        uses: keep-network/ci/actions/upstream-builds-query@move-actions-to-ci # TODO: change to @v1 before merging to main
+        uses: keep-network/ci/actions/upstream-builds-query@v1
         id: upstream-builds-query
         with:
           upstream-builds: ${{ github.event.inputs.upstream_builds }}
@@ -125,7 +125,7 @@ jobs:
           npm publish --access=public --dry-run
 
       - name: Notify CI about completion of the workflow
-        uses: keep-network/ci/actions/notify-workflow-completed@move-actions-to-ci # TODO: change to @v1 before merging to main
+        uses: keep-network/ci/actions/notify-workflow-completed@v1
         env:
           GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
We've moved custom actions used in the Keep/tBTC Continuous Integration
from separate repositories to `ci` repository (under `actions` folder).
We now need to update all the actions' invokations.

Refs:
https://github.com/keep-network/ci/pull/11
https://github.com/keep-network/keep-core/pull/2545
https://github.com/keep-network/keep-ecdsa/pull/868
https://github.com/keep-network/tbtc/pull/816
https://github.com/keep-network/tbtc-dapp/pull/400
https://github.com/keep-network/tbtc.js/pull/128

TODO:
- [x] test deployment flow on the feature branch
- [x] point to `@v1` in lines invoking actions (same change required in other repos)