### PR TITLE
Deposited event

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@ artifacts/
 build/
 cache/
 deployments/
+typechain/

--- a/contracts/AssetPool.sol
+++ b/contracts/AssetPool.sol
@@ -65,6 +65,12 @@ contract AssetPool is Ownable, IAssetPool {
     mapping(address => uint256) public withdrawalInitiatedTimestamp;
     mapping(address => uint256) public pendingWithdrawal;
 
+    event Deposited(
+        address indexed underwrtier,
+        uint256 amount,
+        uint256 covAmount
+    );
+
     event CoverageClaimed(address recipient, uint256 amount, uint256 timestamp);
 
     event WithdrawalInitiated(
@@ -543,6 +549,8 @@ contract AssetPool is Ownable, IAssetPool {
             amountToMint > 0,
             "Minted tokens amount must be greater than 0"
         );
+
+        emit Deposited(depositor, amountToDeposit, amountToMint);
 
         underwriterToken.mint(depositor, amountToMint);
         collateralToken.safeTransferFrom(


### PR DESCRIPTION
When the underwriter deposits into the pool, we need to emit an event. We
could use a `Transfer` event instead but this would not allow us to
distinguish between a deposit and donation. Also, the rewards pool will be
transferring to the asset pool when releasing rewards.