### PR TITLE
Fixes for audit issues

### DIFF
--- a/contracts/AssetPool.sol
+++ b/contracts/AssetPool.sol
@@ -71,7 +71,7 @@ contract AssetPool is Ownable, IAssetPool {
         uint256 covAmount
     );
 
-    event CoverageClaimed(address recipient, uint256 amount, uint256 timestamp);
+    event CoverageClaimed(address indexed recipient, uint256 amount, uint256 timestamp);
 
     event WithdrawalInitiated(
         address indexed underwriter,

--- a/contracts/AssetPool.sol
+++ b/contracts/AssetPool.sol
@@ -173,10 +173,15 @@ contract AssetPool is Ownable, IAssetPool {
     ///      required amount accepted to transfer to the asset pool.
     /// @param amountToDeposit Collateral tokens amount that a user deposits to
     ///                        the asset pool
-    function deposit(uint256 amountToDeposit) external override {
+    /// @return The amount of minted underwriter tokens
+    function deposit(uint256 amountToDeposit)
+        external
+        override
+        returns (uint256)
+    {
         uint256 toMint = _calculateTokensToMint(amountToDeposit);
-
         _deposit(msg.sender, amountToDeposit, toMint);
+        return toMint;
     }
 
     /// @notice Accepts the given amount of collateral token as a deposit and
@@ -189,9 +194,11 @@ contract AssetPool is Ownable, IAssetPool {
     /// @param minAmountToMint Underwriter minimal tokens amount that a user
     ///                        expects to receive in exchange for the deposited
     ///                        collateral tokens
+    /// @return The amount of minted underwriter tokens
     function depositWithMin(uint256 amountToDeposit, uint256 minAmountToMint)
         external
         override
+        returns (uint256)
     {
         uint256 toMint = _calculateTokensToMint(amountToDeposit);
 
@@ -201,6 +208,7 @@ contract AssetPool is Ownable, IAssetPool {
         );
 
         _deposit(msg.sender, amountToDeposit, toMint);
+        return toMint;
     }
 
     /// @notice Initiates the withdrawal of collateral and rewards from the

--- a/contracts/AssetPool.sol
+++ b/contracts/AssetPool.sol
@@ -71,7 +71,11 @@ contract AssetPool is Ownable, IAssetPool {
         uint256 covAmount
     );
 
-    event CoverageClaimed(address indexed recipient, uint256 amount, uint256 timestamp);
+    event CoverageClaimed(
+        address indexed recipient,
+        uint256 amount,
+        uint256 timestamp
+    );
 
     event WithdrawalInitiated(
         address indexed underwriter,

--- a/contracts/AssetPool.sol
+++ b/contracts/AssetPool.sol
@@ -135,8 +135,8 @@ contract AssetPool is Ownable, IAssetPool {
     ///         mints underwriter tokens representing pool's ownership.
     ///         Optional data in extraData may include a minimal amount of
     ///         underwriter tokens expected to be minted for a depositor. There
-    ///         cases when an amount of minted tokens matters for a depositor, ex
-    ///         tokens might be used in third party exchanges.
+    ///         are cases when an amount of minted tokens matters for a
+    ///         depositor, as tokens might be used in third party exchanges.
     /// @dev This function is a shortcut for approve + deposit.
     function receiveApproval(
         address from,

--- a/contracts/AssetPool.sol
+++ b/contracts/AssetPool.sol
@@ -191,6 +191,7 @@ contract AssetPool is Ownable, IAssetPool {
     ///                        collateral tokens
     function depositWithMin(uint256 amountToDeposit, uint256 minAmountToMint)
         external
+        override
     {
         uint256 toMint = _calculateTokensToMint(amountToDeposit);
 

--- a/contracts/interfaces/IAssetPool.sol
+++ b/contracts/interfaces/IAssetPool.sol
@@ -25,7 +25,7 @@ interface IAssetPool {
     ///         mints underwriter tokens representing pool's ownership.
     /// @dev Before calling this function, collateral token needs to have the
     ///      required amount accepted to transfer to the asset pool.
-    function deposit(uint256 amount) external;
+    function deposit(uint256 amount) external returns (uint256);
 
     /// @notice Accepts the given amount of collateral token as a deposit and
     ///         mints at least a minAmountToMint underwriter tokens representing
@@ -33,7 +33,8 @@ interface IAssetPool {
     /// @dev Before calling this function, collateral token needs to have the
     ///      required amount accepted to transfer to the asset pool.
     function depositWithMin(uint256 amountToDeposit, uint256 minAmountToMint)
-        external;
+        external
+        returns (uint256);
 
     /// @notice Initiates the withdrawal of collateral and rewards from the pool.
     /// @dev Before calling this function, underwriter token needs to have the

--- a/contracts/interfaces/IAssetPool.sol
+++ b/contracts/interfaces/IAssetPool.sol
@@ -27,6 +27,14 @@ interface IAssetPool {
     ///      required amount accepted to transfer to the asset pool.
     function deposit(uint256 amount) external;
 
+    /// @notice Accepts the given amount of collateral token as a deposit and
+    ///         mints at least a minAmountToMint underwriter tokens representing
+    ///         pool's ownership.
+    /// @dev Before calling this function, collateral token needs to have the
+    ///      required amount accepted to transfer to the asset pool.
+    function depositWithMin(uint256 amountToDeposit, uint256 minAmountToMint)
+        external;
+
     /// @notice Initiates the withdrawal of collateral and rewards from the pool.
     /// @dev Before calling this function, underwriter token needs to have the
     ///      required amount accepted to transfer to the asset pool.

--- a/test/AssetPool.test.js
+++ b/test/AssetPool.test.js
@@ -322,9 +322,10 @@ describe("AssetPool", () => {
       () => {
         const depositedUnderwriter1 = to1e18(100)
         const minCovToMint1 = depositedUnderwriter1
+        let tx
 
         beforeEach(async () => {
-          await assetPool
+          tx = await assetPool
             .connect(underwriter1)
             .depositWithMin(depositedUnderwriter1, minCovToMint1)
         })
@@ -339,6 +340,16 @@ describe("AssetPool", () => {
           expect(
             await underwriterToken.balanceOf(underwriter1.address)
           ).to.equal(to1e18(100))
+        })
+
+        it("should emit Deposited event", async () => {
+          await expect(tx)
+            .to.emit(assetPool, "Deposited")
+            .withArgs(
+              underwriter1.address,
+              depositedUnderwriter1,
+              depositedUnderwriter1
+            )
         })
       }
     )


### PR DESCRIPTION
This PR includes minor fixes:
- added index to an event param
- fixed typos
- moved function `depositWithMin` to `IAssetPool` interface
- added return values to `deposit` and `depositWithMin`

Note: No unit tests checking return values of `deposit` and `depositWithMin` were added as there seems to be no way to test the return values from `non-constant`  (`non-view` or `non-pure` functions) as explained [here](https://ethereum.stackexchange.com/a/88122).

One workaround is using events (which we use - we emit `Deposited` event) and those are checked in our unit tests.
 

