### PR TITLE
Cancelling already approved new asset pool

### DIFF
--- a/contracts/AssetPool.sol
+++ b/contracts/AssetPool.sol
@@ -372,12 +372,9 @@ contract AssetPool is Ownable, IAssetPool {
 
     /// @notice Allows governance to cancel already approved new asset pool
     ///         in case of some misconfiguration.
-    function cancelNewAssetPoolUpgrade()
-        external
-        onlyOwner
-    {
+    function cancelNewAssetPoolUpgrade() external onlyOwner {
         emit CancelledAssetPoolUpgrade(address(newAssetPool));
-        
+
         newAssetPool = IAssetPoolUpgrade(address(0));
     }
 

--- a/contracts/AssetPool.sol
+++ b/contracts/AssetPool.sol
@@ -85,6 +85,7 @@ contract AssetPool is Ownable, IAssetPool {
     );
 
     event ApprovedAssetPoolUpgrade(address newAssetPool);
+    event CancelledAssetPoolUpgrade(address cancelledAssetPool);
     event AssetPoolUpgraded(
         address indexed underwriter,
         uint256 collateralAmount,
@@ -367,6 +368,17 @@ contract AssetPool is Ownable, IAssetPool {
         newAssetPool = _newAssetPool;
 
         emit ApprovedAssetPoolUpgrade(address(_newAssetPool));
+    }
+
+    /// @notice Allows governance to cancel already approved new asset pool
+    ///         in case of some misconfiguration.
+    function cancelNewAssetPoolUpgrade()
+        external
+        onlyOwner
+    {
+        emit CancelledAssetPoolUpgrade(address(newAssetPool));
+        
+        newAssetPool = IAssetPoolUpgrade(address(0));
     }
 
     /// @notice Allows the coverage pool to demand coverage from the asset hold

--- a/test/AssetPool.test.js
+++ b/test/AssetPool.test.js
@@ -5,6 +5,7 @@ const {
   lastBlockTime,
   to1ePrecision,
   pastEvents,
+  ZERO_ADDRESS,
 } = require("./helpers/contract-test-helpers")
 
 describe("AssetPool", () => {
@@ -1185,6 +1186,60 @@ describe("AssetPool", () => {
           assetPool
             .connect(thirdParty)
             .approveNewAssetPoolUpgrade(newAssetPool.address)
+        ).to.be.revertedWith("Ownable: caller is not the owner")
+      })
+    })
+  })
+
+  describe("cancelNewAssetPoolUpgrade", () => {
+    let newAssetPool
+
+    beforeEach(async () => {
+      const NewUnderwriterToken = await ethers.getContractFactory(
+        "UnderwriterToken"
+      )
+      newUnderwriterToken = await NewUnderwriterToken.deploy(
+        "New Underwriter Token",
+        "newCOV"
+      )
+      await newUnderwriterToken.deployed()
+
+      const NewAssetPoolStub = await ethers.getContractFactory(
+        "NewAssetPoolStub"
+      )
+      newAssetPool = await NewAssetPoolStub.deploy(
+        collateralToken.address,
+        newUnderwriterToken.address
+      )
+      await newAssetPool.deployed()
+
+      await assetPool
+        .connect(coveragePool)
+        .approveNewAssetPoolUpgrade(newAssetPool.address)
+    })
+
+    context("when called by the governance", () => {
+      it("should cancel already approved new asset pool", async () => {
+        await assetPool.connect(coveragePool).cancelNewAssetPoolUpgrade()
+
+        expect(await assetPool.newAssetPool()).to.equal(ZERO_ADDRESS)
+      })
+
+      it("should emit CancelledAssetPoolUpgrade event", async () => {
+        const tx = await assetPool
+          .connect(coveragePool)
+          .cancelNewAssetPoolUpgrade()
+
+        expect(tx)
+          .to.emit(assetPool, "CancelledAssetPoolUpgrade")
+          .withArgs(newAssetPool.address)
+      })
+    })
+
+    context("when called not by the governance", () => {
+      it("should revert", async () => {
+        await expect(
+          assetPool.connect(thirdParty).cancelNewAssetPoolUpgrade()
         ).to.be.revertedWith("Ownable: caller is not the owner")
       })
     })


### PR DESCRIPTION
In case of some misconfiguration of a new asset pool, we give a governance an option to set already approved asset pool back to zero address.