### PR TITLE
Removed redundant balance checks, simplified TestToken

### DIFF
--- a/contracts/AssetPool.sol
+++ b/contracts/AssetPool.sol
@@ -212,12 +212,6 @@ contract AssetPool is Ownable, IAssetPool {
     /// @dev Before calling this function, underwriter token needs to have the
     ///      required amount accepted to transfer to the asset pool.
     function initiateWithdrawal(uint256 covAmount) external override {
-        uint256 covBalance = underwriterToken.balanceOf(msg.sender);
-        require(
-            covAmount <= covBalance,
-            "Underwriter token amount exceeds balance"
-        );
-
         uint256 pending = pendingWithdrawal[msg.sender];
         require(
             covAmount > 0 || pending > 0,
@@ -316,12 +310,6 @@ contract AssetPool is Ownable, IAssetPool {
             "Underwriter token amount must be greater than 0"
         );
 
-        uint256 covBalance = underwriterToken.balanceOf(msg.sender);
-        require(
-            covAmount <= covBalance,
-            "Underwriter token amount exceeds available balance"
-        );
-
         uint256 covSupply = underwriterToken.totalSupply();
 
         // slither-disable-next-line reentrancy-events
@@ -336,6 +324,9 @@ contract AssetPool is Ownable, IAssetPool {
             address(newAssetPool),
             collateralToTransfer
         );
+        // old underwriter tokens are burned in favor of new minted in a new
+        // asset pool
+        underwriterToken.burnFrom(msg.sender, covAmount);
         // collateralToTransfer will be sent to a new AssetPool and new
         // underwriter tokens will be minted and transferred back to the underwriter
         newAssetPool.depositFor(msg.sender, collateralToTransfer);
@@ -346,10 +337,6 @@ contract AssetPool is Ownable, IAssetPool {
             covAmount,
             block.timestamp
         );
-
-        // old underwriter tokens are burned in favor of new minted in a new
-        // asset pool
-        underwriterToken.burnFrom(msg.sender, covAmount);
     }
 
     /// @notice Allows governance to set a new asset pool so the underwriters

--- a/contracts/UnderwriterToken.sol
+++ b/contracts/UnderwriterToken.sol
@@ -16,8 +16,6 @@ pragma solidity 0.8.4;
 
 import "@thesis/solidity-contracts/contracts/token/ERC20WithPermit.sol";
 
-import "./AssetPool.sol";
-
 /// @title  UnderwriterToken
 /// @notice Underwriter tokens represent an ownership share in the underlying
 ///         collateral of the asset-specific pool. Underwriter tokens are minted

--- a/contracts/test/TestToken.sol
+++ b/contracts/test/TestToken.sol
@@ -2,46 +2,9 @@
 
 pragma solidity 0.8.4;
 
-import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@thesis/solidity-contracts/contracts/token/ERC20WithPermit.sol";
 
-// See https://github.com/keep-network/keep-core/blob/v1.0.1/solidity/contracts/KeepToken.sol
-interface tokenRecipient {
-    function receiveApproval(
-        address _from,
-        uint256 _value,
-        address _token,
-        bytes calldata _extraData
-    ) external;
-}
-
-contract TestToken is ERC20 {
-    string public constant NAME = "Test Token";
-    string public constant SYMBOL = "TT";
-
+contract TestToken is ERC20WithPermit {
     /* solhint-disable-next-line no-empty-blocks */
-    constructor() ERC20(NAME, SYMBOL) {}
-
-    /// @dev             Mints an amount of the token and assigns it to an account.
-    ///                  Uses the internal _mint function. Anyone can call
-    /// @param account  The account that will receive the created tokens.
-    /// @param amount   The amount of tokens that will be created.
-    function mint(address account, uint256 amount) public {
-        _mint(account, amount);
-    }
-
-    function approveAndCall(
-        address spender,
-        uint256 value,
-        bytes memory extraData
-    ) public returns (bool success) {
-        if (approve(spender, value)) {
-            tokenRecipient(spender).receiveApproval(
-                msg.sender,
-                value,
-                address(this),
-                extraData
-            );
-            return true;
-        }
-    }
+    constructor() ERC20WithPermit("Test Token", "TT") {}
 }

--- a/test/AssetPool.test.js
+++ b/test/AssetPool.test.js
@@ -541,9 +541,12 @@ describe("AssetPool", () => {
 
     context("when underwriter has not enough underwriter tokens", () => {
       it("should revert", async () => {
+        await underwriterToken
+          .connect(underwriter1)
+          .approve(assetPool.address, amount.add(1))
         await expect(
           assetPool.connect(underwriter1).initiateWithdrawal(amount.add(1))
-        ).to.be.revertedWith("Underwriter token amount exceeds balance")
+        ).to.be.revertedWith("Transfer amount exceeds balance")
       })
     })
 
@@ -1257,9 +1260,7 @@ describe("AssetPool", () => {
           assetPool
             .connect(underwriter1)
             .upgradeToNewAssetPool(amountToUpgrade, newAssetPool.address)
-        ).to.be.revertedWith(
-          "Underwriter token amount exceeds available balance"
-        )
+        ).to.be.revertedWith("Burn amount exceeds allowance")
       })
     })
 

--- a/test/AssetPool.test.js
+++ b/test/AssetPool.test.js
@@ -86,9 +86,12 @@ describe("AssetPool", () => {
     context("when the depositor has not enough collateral tokens", () => {
       it("should revert", async () => {
         const amount = underwriterInitialCollateralBalance.add(1)
+        await collateralToken
+          .connect(underwriter1)
+          .approve(assetPool.address, amount)
         await expect(
           assetPool.connect(underwriter1).deposit(amount)
-        ).to.be.revertedWith("ERC20: transfer amount exceeds balance")
+        ).to.be.revertedWith("Transfer amount exceeds balance")
       })
     })
 

--- a/test/RewardsPool.test.js
+++ b/test/RewardsPool.test.js
@@ -86,7 +86,7 @@ describe("RewardsPool", () => {
         // the entire allowance was spent in beforeEach
         await expect(
           pool.connect(rewardManager).topUpReward(topUpAmount)
-        ).to.be.revertedWith("ERC20: transfer amount exceeds allowance")
+        ).to.be.revertedWith("Transfer amount exceeds allowance")
       })
 
       it("should emit RewardToppedUp event", async () => {


### PR DESCRIPTION
The main change in this PR is the removal of redundant `balanceOf` 
checks in the  `AssetPool`.

In case of `initiateWithdrawal`, `safeTransferFrom` will fail in case
the withdrawing party has not enough covKEEP on their balance. covKEEP
inherits from `ERC20WithPermit` and behaves correctly so there is no risk
here.

In case of `upgradeToNewAssetPool`, `burnFrom` in the underwriter token
fails in case the upgrading party has not enough on their balance.
covKEEP inherits from `ERC20WithPermit` and behaves correctly so there is
no risk here.
To make the revert cause in this case more clear, I have switched the
order of `burnFrom` and `depositFor` calls. In case there is not enough
tokens on underwriter's balance, it is better to revert saying burn
amount exceeds balance instead of reverting with transfer amount exceeds
balance in the new asset pool, in case the new underwriter exceeded the
amount so significantly that the transfer amount exceeds pool's balance.

I have packed two other small changes into this PR:
- Removed unused import to `AssetPool` from `UnderwriterToken` contract.
- Made `TestToken` to inherit from `ERC20WithPermit` to reduce the complexity
in the test contract to an absolute minimum.