### PR TITLE
Risk manager approval changes

### DIFF
--- a/contracts/CoveragePool.sol
+++ b/contracts/CoveragePool.sol
@@ -76,8 +76,10 @@ contract CoveragePool is Ownable {
     function beginRiskManagerApproval(address riskManager) external onlyOwner {
         require(
             firstRiskManagerApproved,
-            "First risk manager was not approved"
+            "The first risk manager is not yet approved; Please use "
+            "approveFirstRiskManager instead"
         );
+
         /* solhint-disable-next-line not-rely-on-time */
         riskManagerApprovalTimestamps[riskManager] = block.timestamp;
         /* solhint-disable-next-line not-rely-on-time */

--- a/contracts/CoveragePool.sol
+++ b/contracts/CoveragePool.sol
@@ -68,11 +68,16 @@ contract CoveragePool is Ownable {
     }
 
     /// @notice Begins risk manager approval process.
-    /// @dev Can be called only by the contract owner. For a risk manager to be
+    /// @dev Can be called only by the contract owner and only when the first
+    ///      risk manager is already approved. For a risk manager to be
     ///      approved, a call to `finalizeRiskManagerApproval` must follow
     ///      (after a governance delay).
     /// @param riskManager Risk manager that will be approved
     function beginRiskManagerApproval(address riskManager) external onlyOwner {
+        require(
+            firstRiskManagerApproved,
+            "First risk manager was not approved"
+        );
         /* solhint-disable-next-line not-rely-on-time */
         riskManagerApprovalTimestamps[riskManager] = block.timestamp;
         /* solhint-disable-next-line not-rely-on-time */

--- a/contracts/CoveragePool.sol
+++ b/contracts/CoveragePool.sol
@@ -108,13 +108,17 @@ contract CoveragePool is Ownable {
         delete riskManagerApprovalTimestamps[riskManager];
     }
 
-    /// @notice Unapproves the risk manager. The change takes effect immediately.
+    /// @notice Unapproves an already approved risk manager or cancels the
+    ///         approval process of a risk manager (the latter happens if called
+    ///         between `beginRiskManagerApproval` and `finalizeRiskManagerApproval`).
+    ///         The change takes effect immediately.
     /// @dev Can be called only by the contract owner.
     /// @param riskManager Risk manager that will be unapproved
     function unapproveRiskManager(address riskManager) external onlyOwner {
+        delete riskManagerApprovalTimestamps[riskManager];
+        delete approvedRiskManagers[riskManager];
         /* solhint-disable-next-line not-rely-on-time */
         emit RiskManagerUnapproved(riskManager, block.timestamp);
-        delete approvedRiskManagers[riskManager];
     }
 
     /// @notice Approves upgradeability to the new asset pool.

--- a/test/CoveragePool.test.js
+++ b/test/CoveragePool.test.js
@@ -258,12 +258,6 @@ describe("CoveragePool", () => {
   })
 
   describe("unapproveRiskManager", () => {
-    beforeEach(async () => {
-      await coveragePool
-        .connect(governance)
-        .approveFirstRiskManager(riskManager.address)
-    })
-
     context("when caller is not the governance", () => {
       it("should revert", async () => {
         await expect(
@@ -274,10 +268,37 @@ describe("CoveragePool", () => {
       })
     })
 
-    context("when caller is the governance", () => {
-      let tx
-
+    context("when cancelling risk manager approval process", () => {
       beforeEach(async () => {
+        await coveragePool
+          .connect(governance)
+          .approveFirstRiskManager(anotherRiskManager.address)
+        await coveragePool
+          .connect(governance)
+          .beginRiskManagerApproval(riskManager.address)
+        tx = await coveragePool
+          .connect(governance)
+          .unapproveRiskManager(riskManager.address)
+      })
+
+      it("should remove timestamp of risk manager", async () => {
+        expect(
+          await coveragePool.riskManagerApprovalTimestamps(riskManager.address)
+        ).to.be.equal(0)
+      })
+
+      it("should emit RiskManagerUnapproved event", async () => {
+        await expect(tx)
+          .to.emit(coveragePool, "RiskManagerUnapproved")
+          .withArgs(riskManager.address, await lastBlockTime())
+      })
+    })
+
+    context("when unapproving risk manager", () => {
+      beforeEach(async () => {
+        await coveragePool
+          .connect(governance)
+          .approveFirstRiskManager(riskManager.address)
         tx = await coveragePool
           .connect(governance)
           .unapproveRiskManager(riskManager.address)

--- a/test/CoveragePool.test.js
+++ b/test/CoveragePool.test.js
@@ -127,47 +127,55 @@ describe("CoveragePool", () => {
           coveragePool
             .connect(governance)
             .beginRiskManagerApproval(riskManager.address)
-        ).to.be.revertedWith("First risk manager was not approved")
+        ).to.be.revertedWith(
+          "The first risk manager is not yet approved; Please use " +
+            "approveFirstRiskManager instead"
+        )
       })
     })
 
-    context("when first risk manager was approved", () => {
-      let tx
-      beforeEach(async () => {
-        await coveragePool
-          .connect(governance)
-          .approveFirstRiskManager(anotherRiskManager.address)
-        tx = await coveragePool
-          .connect(governance)
-          .beginRiskManagerApproval(riskManager.address)
-      })
+    context(
+      "when called by the governance and first risk manager was approved",
+      () => {
+        let tx
+        beforeEach(async () => {
+          await coveragePool
+            .connect(governance)
+            .approveFirstRiskManager(anotherRiskManager.address)
+          tx = await coveragePool
+            .connect(governance)
+            .beginRiskManagerApproval(riskManager.address)
+        })
 
-      it("should not approve risk manager", async () => {
-        expect(await coveragePool.approvedRiskManagers(riskManager.address)).to
-          .be.false
-      })
+        it("should not approve risk manager", async () => {
+          expect(await coveragePool.approvedRiskManagers(riskManager.address))
+            .to.be.false
+        })
 
-      it("should store approval process begin timestamp", async () => {
-        expect(
-          await coveragePool.riskManagerApprovalTimestamps(riskManager.address)
-        ).to.be.above(0)
-      })
+        it("should store approval process begin timestamp", async () => {
+          expect(
+            await coveragePool.riskManagerApprovalTimestamps(
+              riskManager.address
+            )
+          ).to.be.above(0)
+        })
 
-      it("should emit RiskManagerApprovalStarted event", async () => {
-        await expect(tx)
-          .to.emit(coveragePool, "RiskManagerApprovalStarted")
-          .withArgs(riskManager.address, await lastBlockTime())
-      })
+        it("should emit RiskManagerApprovalStarted event", async () => {
+          await expect(tx)
+            .to.emit(coveragePool, "RiskManagerApprovalStarted")
+            .withArgs(riskManager.address, await lastBlockTime())
+        })
 
-      it("should start the governance delay timer", async () => {
-        const governanceDelay = await assetPool.withdrawalGovernanceDelay()
-        expect(
-          await coveragePool.getRemainingRiskManagerApprovalTime(
-            riskManager.address
-          )
-        ).to.be.equal(governanceDelay)
-      })
-    })
+        it("should start the governance delay timer", async () => {
+          const governanceDelay = await assetPool.withdrawalGovernanceDelay()
+          expect(
+            await coveragePool.getRemainingRiskManagerApprovalTime(
+              riskManager.address
+            )
+          ).to.be.equal(governanceDelay)
+        })
+      }
+    )
   })
 
   describe("finalizeRiskManagerApproval", () => {
@@ -281,7 +289,7 @@ describe("CoveragePool", () => {
           .unapproveRiskManager(riskManager.address)
       })
 
-      it("should remove timestamp of risk manager", async () => {
+      it("should remove timestamp of risk manager approval", async () => {
         expect(
           await coveragePool.riskManagerApprovalTimestamps(riskManager.address)
         ).to.be.equal(0)


### PR DESCRIPTION
This PR changes the risk manager approval process:
- requires the first risk manager to be approved before the process of approval of another risk manager begins
- risk manager approval process can be cancelled with `unapproveRiskManager`
