### PR TITLE
Update hardhat version and fix unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "eslint-config-keep": "github:keep-network/eslint-config-keep#0c27ade",
     "ethereum-waffle": "^3.3.0",
     "ethers": "^5.0.32",
-    "hardhat": "^2.2.1",
+    "hardhat": "2.6.1",
     "hardhat-deploy": "^0.8.11",
     "hardhat-gas-reporter": "^1.0.4",
     "prettier": "^2.3.2",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "eslint-config-keep": "github:keep-network/eslint-config-keep#0c27ade",
     "ethereum-waffle": "^3.3.0",
     "ethers": "^5.0.32",
-    "hardhat": "2.6.1",
+    "hardhat": "^2.6.1",
     "hardhat-deploy": "^0.8.11",
     "hardhat-gas-reporter": "^1.0.4",
     "prettier": "^2.3.2",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "eslint-config-keep": "github:keep-network/eslint-config-keep#0c27ade",
     "ethereum-waffle": "^3.3.0",
     "ethers": "^5.0.32",
-    "hardhat": "^2.1.1",
+    "hardhat": "^2.2.1",
     "hardhat-deploy": "^0.8.11",
     "hardhat-gas-reporter": "^1.0.4",
     "prettier": "^2.3.2",

--- a/test/Auction.test.js
+++ b/test/Auction.test.js
@@ -151,6 +151,9 @@ describe("Auction", () => {
         // add 100sec
         await increaseTime(100)
 
+        // make sure auction did not self destruct
+        expect(await isCodeAt(auction.address)).to.be.true
+
         expect(await auction.isOpen()).to.be.equal(true)
       })
     })
@@ -162,6 +165,10 @@ describe("Auction", () => {
         auction = await createAuction(auctionAmountDesired, auctionLength)
 
         await increaseTime(24000)
+      })
+
+      it("should not self destruct", async () => {
+        expect(await isCodeAt(auction.address)).to.be.true
       })
 
       it("should be opened", async () => {
@@ -515,6 +522,10 @@ describe("Auction", () => {
           // Increase time so the auction ends
           // 3,600 + 82,800 + 1 = 86401sec (auction ended)
           await increaseTime(82801)
+          // when auction ends and is partially filled, it should not self
+          // destruct
+          expect(await isCodeAt(auction.address)).to.be.true
+
           // when auction ends and is partially filled, it should stay opened
           expect(await auction.isOpen()).to.be.equal(true)
         })

--- a/test/Auction.test.js
+++ b/test/Auction.test.js
@@ -167,11 +167,8 @@ describe("Auction", () => {
         await increaseTime(24000)
       })
 
-      it("should not self destruct", async () => {
-        expect(await isCodeAt(auction.address)).to.be.true
-      })
-
       it("should be opened", async () => {
+        expect(await isCodeAt(auction.address)).to.be.true
         expect(await auction.isOpen()).to.be.equal(true)
       })
 

--- a/test/Auctioneer.test.js
+++ b/test/Auctioneer.test.js
@@ -5,6 +5,7 @@ const {
   to1e18,
   pastEvents,
   increaseTime,
+  isCodeAt,
 } = require("./helpers/contract-test-helpers")
 
 const auctionLength = 86400 // 24h in sec
@@ -264,10 +265,10 @@ describe("Auctioneer", () => {
     })
 
     context("when the auction is still open", () => {
-      it("should close the auction", async () => {
+      it("should destroy the auction", async () => {
         await auctioneer.connect(bidder).publicEarlyCloseAuction(auctionAddress)
 
-        expect(await auction.isOpen()).to.be.false
+        expect(await isCodeAt(auctionAddress)).to.be.false
       })
 
       it("should emit the auction closed event", async () => {

--- a/test/helpers/contract-test-helpers.js
+++ b/test/helpers/contract-test-helpers.js
@@ -78,6 +78,13 @@ async function resetFork(blockNumber) {
   })
 }
 
+// This function checks whether the given address stores contract code. It
+// can be used to determine whether a contract stored at the given address has
+// self destructed.
+async function isCodeAt(address) {
+  return (await ethers.provider.getCode(address)) != ethers.utils.hexlify("0x")
+}
+
 module.exports.to1ePrecision = to1ePrecision
 module.exports.to1e18 = to1e18
 module.exports.pastEvents = pastEvents
@@ -85,5 +92,6 @@ module.exports.lastBlockTime = lastBlockTime
 module.exports.increaseTime = increaseTime
 module.exports.impersonateAccount = impersonateAccount
 module.exports.resetFork = resetFork
+module.exports.isCodeAt = isCodeAt
 
 module.exports.ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"

--- a/test/system/liquidation-multiple-take-offers.test.js
+++ b/test/system/liquidation-multiple-take-offers.test.js
@@ -7,6 +7,7 @@ const {
   resetFork,
   ZERO_ADDRESS,
   increaseTime,
+  isCodeAt,
 } = require("../helpers/contract-test-helpers")
 const {
   underwriterAddress,
@@ -128,8 +129,8 @@ describeFn("System -- multiple partial fills", () => {
       tx = await auction.connect(bidder2).takeOffer(lotSize.mul(60).div(100))
     })
 
-    it("should close auction", async () => {
-      expect(await auction.isOpen()).to.be.false
+    it("should destroy auction", async () => {
+      expect(await isCodeAt(auction.address)).to.be.false
     })
 
     it("should decrease the amount of TBTC for bidders", async () => {
@@ -177,7 +178,7 @@ describeFn("System -- multiple partial fills", () => {
       expect(parseInt(tx.gasLimit)).to.be.lessThan(370000)
 
       const txReceipt = await ethers.provider.getTransactionReceipt(tx.hash)
-      expect(parseInt(txReceipt.gasUsed)).to.be.lessThan(181000)
+      expect(parseInt(txReceipt.gasUsed)).to.be.lessThan(280000)
     })
   })
 })

--- a/test/system/liquidation.test.js
+++ b/test/system/liquidation.test.js
@@ -181,7 +181,7 @@ describeFn("System -- liquidation", () => {
       await expect(parseInt(tx.gasLimit)).to.be.lessThan(518000)
 
       const txReceipt = await ethers.provider.getTransactionReceipt(tx.hash)
-      await expect(parseInt(txReceipt.gasUsed)).to.be.lessThan(400000)
+      await expect(parseInt(txReceipt.gasUsed)).to.be.lessThan(392000)
     })
   })
 })

--- a/test/system/liquidation.test.js
+++ b/test/system/liquidation.test.js
@@ -136,7 +136,7 @@ describeFn("System -- liquidation", () => {
       tx = await auction.takeOffer(lotSize)
     })
 
-    it("should close auction", async () => {
+    it("should destroy auction", async () => {
       expect(await isCodeAt(auction.address)).to.be.false
     })
 

--- a/test/system/liquidation.test.js
+++ b/test/system/liquidation.test.js
@@ -6,6 +6,7 @@ const {
   resetFork,
   ZERO_ADDRESS,
   increaseTime,
+  isCodeAt,
 } = require("../helpers/contract-test-helpers")
 const hre = require("hardhat")
 
@@ -136,7 +137,7 @@ describeFn("System -- liquidation", () => {
     })
 
     it("should close auction", async () => {
-      expect(await auction.isOpen()).to.be.false
+      expect(await isCodeAt(auction.address)).to.be.false
     })
 
     it("should spend bidder's TBTC", async () => {
@@ -180,7 +181,7 @@ describeFn("System -- liquidation", () => {
       await expect(parseInt(tx.gasLimit)).to.be.lessThan(518000)
 
       const txReceipt = await ethers.provider.getTransactionReceipt(tx.hash)
-      await expect(parseInt(txReceipt.gasUsed)).to.be.lessThan(255000)
+      await expect(parseInt(txReceipt.gasUsed)).to.be.lessThan(400000)
     })
   })
 })

--- a/test/system/surplus-for-auction.test.js
+++ b/test/system/surplus-for-auction.test.js
@@ -6,6 +6,7 @@ const {
   resetFork,
   to1ePrecision,
   ZERO_ADDRESS,
+  isCodeAt,
 } = require("../helpers/contract-test-helpers")
 const Auction = hre.artifacts.readArtifactSync("Auction")
 const { initContracts } = require("./init-contracts")
@@ -159,7 +160,7 @@ describeFn("System -- buying a deposit with surplus", () => {
     })
 
     it("should early close cov pool auction for deposit2", async () => {
-      expect(await auction.isOpen()).to.be.false
+      expect(await isCodeAt(auction.address)).to.be.false
     })
 
     it("should buy deposit3 with surplus TBTC without opening an auction", async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6211,7 +6211,7 @@ hardhat-gas-reporter@^1.0.4:
     eth-gas-reporter "^0.2.20"
     sha1 "^1.1.1"
 
-hardhat@^2.2.1:
+hardhat@2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/hardhat/-/hardhat-2.6.1.tgz#4553ca555c1ba8ed7c3c5a5a93e6082a2869b3ae"
   integrity sha512-0LozdYbPsiTc6ZXsfDQUTV3L0p4CMO5TRbd5qmeWiCYGmhd+7Mvdg4N+nA8w0g3gZ2OKFUmHIYlAbExI488ceQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -271,38 +271,38 @@
     patch-package "^6.2.2"
     postinstall-postinstall "^2.1.0"
 
-"@ethereumjs/block@^3.2.0", "@ethereumjs/block@^3.2.1":
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/@ethereumjs/block/-/block-3.2.1.tgz#c24c345e6dd6299efa4bed40979280b7dda96d3a"
-  integrity sha512-FCxo5KwwULne2A2Yuae4iaGGqSsRjwzXOlDhGalOFiBbLfP3hE04RHaHGw4c8vh1PfOrLauwi0dQNUBkOG3zIA==
+"@ethereumjs/block@^3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/block/-/block-3.4.0.tgz#4747b0c06220ee10cbdfe1cbde8cbb0677b1b074"
+  integrity sha512-umKAoTX32yXzErpIksPHodFc/5y8bmZMnOl6hWy5Vd8xId4+HKFUOyEiN16Y97zMwFRysRpcrR6wBejfqc6Bmg==
   dependencies:
-    "@ethereumjs/common" "^2.2.0"
-    "@ethereumjs/tx" "^3.1.3"
-    ethereumjs-util "^7.0.10"
-    merkle-patricia-tree "^4.1.0"
+    "@ethereumjs/common" "^2.4.0"
+    "@ethereumjs/tx" "^3.3.0"
+    ethereumjs-util "^7.1.0"
+    merkle-patricia-tree "^4.2.0"
 
-"@ethereumjs/blockchain@^5.2.1":
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/@ethereumjs/blockchain/-/blockchain-5.2.1.tgz#83ed83647667265f1666f111caf065ef9d1e82b5"
-  integrity sha512-+hshP2qSOOFsiYvZCbaDQFG7jYTWafE8sfBi+pAsdhAHfP7BN7VLyob7qoQISgwS1s7NTR4c4+2t/woU9ahItw==
+"@ethereumjs/blockchain@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/blockchain/-/blockchain-5.4.0.tgz#28d712627d3442b2bb1f50dd5acba7cde1021993"
+  integrity sha512-wAuKLaew6PL52kH8YPXO7PbjjKV12jivRSyHQehkESw4slSLLfYA6Jv7n5YxyT2ajD7KNMPVh7oyF/MU6HcOvg==
   dependencies:
-    "@ethereumjs/block" "^3.2.0"
-    "@ethereumjs/common" "^2.2.0"
+    "@ethereumjs/block" "^3.4.0"
+    "@ethereumjs/common" "^2.4.0"
     "@ethereumjs/ethash" "^1.0.0"
     debug "^2.2.0"
-    ethereumjs-util "^7.0.9"
+    ethereumjs-util "^7.1.0"
     level-mem "^5.0.1"
     lru-cache "^5.1.1"
     rlp "^2.2.4"
     semaphore-async-await "^1.5.1"
 
-"@ethereumjs/common@^2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@ethereumjs/common/-/common-2.2.0.tgz#850a3e3e594ee707ad8d44a11e8152fb62450535"
-  integrity sha512-PyQiTG00MJtBRkJmv46ChZL8u2XWxNBeAthznAUIUiefxPAXjbkuiCZOuncgJS34/XkMbNc9zMt/PlgKRBElig==
+"@ethereumjs/common@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/common/-/common-2.4.0.tgz#2d67f6e6ba22246c5c89104e6b9a119fb3039766"
+  integrity sha512-UdkhFWzWcJCZVsj1O/H8/oqj/0RVYjLc1OhPjBrQdALAkQHpCp8xXI4WLnuGTADqTdJZww0NtgwG+TRPkXt27w==
   dependencies:
     crc-32 "^1.2.0"
-    ethereumjs-util "^7.0.9"
+    ethereumjs-util "^7.1.0"
 
 "@ethereumjs/ethash@^1.0.0":
   version "1.0.0"
@@ -314,30 +314,30 @@
     ethereumjs-util "^7.0.7"
     miller-rabin "^4.0.0"
 
-"@ethereumjs/tx@^3.1.3":
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/@ethereumjs/tx/-/tx-3.1.3.tgz#0e4b0ccec2f12b1f0bbbb0e7542dd79d9ec25d87"
-  integrity sha512-DJBu6cbwYtiPTFeCUR8DF5p+PF0jxs+0rALJZiEcTz2tiRPIEkM72GEbrkGuqzENLCzBrJHT43O0DxSYTqeo+g==
+"@ethereumjs/tx@^3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/tx/-/tx-3.3.0.tgz#14ed1b7fa0f28e1cd61e3ecbdab824205f6a4378"
+  integrity sha512-yTwEj2lVzSMgE6Hjw9Oa1DZks/nKTWM8Wn4ykDNapBPua2f4nXO3qKnni86O6lgDj5fVNRqbDsD0yy7/XNGDEA==
   dependencies:
-    "@ethereumjs/common" "^2.2.0"
-    ethereumjs-util "^7.0.10"
+    "@ethereumjs/common" "^2.4.0"
+    ethereumjs-util "^7.1.0"
 
-"@ethereumjs/vm@^5.3.2":
-  version "5.3.2"
-  resolved "https://registry.yarnpkg.com/@ethereumjs/vm/-/vm-5.3.2.tgz#b4d83a3d50a7ad22d6d412cc21bbde221b3e2871"
-  integrity sha512-QmCUQrW6xbhgEbQh9njue4kAJdM056C+ytBFUTF/kDYa3kNDm4Qxp9HUyTlt1OCSXvDhws0qqlh8+q+pmXpN7g==
+"@ethereumjs/vm@^5.5.2":
+  version "5.5.2"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/vm/-/vm-5.5.2.tgz#918a2c1000aaa9fdbe6007a4fdc2c62833122adf"
+  integrity sha512-AydZ4wfvZAsBuFzs3xVSA2iU0hxhL8anXco3UW3oh9maVC34kTEytOfjHf06LTEfN0MF9LDQ4ciLa7If6ZN/sg==
   dependencies:
-    "@ethereumjs/block" "^3.2.1"
-    "@ethereumjs/blockchain" "^5.2.1"
-    "@ethereumjs/common" "^2.2.0"
-    "@ethereumjs/tx" "^3.1.3"
+    "@ethereumjs/block" "^3.4.0"
+    "@ethereumjs/blockchain" "^5.4.0"
+    "@ethereumjs/common" "^2.4.0"
+    "@ethereumjs/tx" "^3.3.0"
     async-eventemitter "^0.2.4"
     core-js-pure "^3.0.1"
     debug "^2.2.0"
-    ethereumjs-util "^7.0.10"
+    ethereumjs-util "^7.1.0"
     functional-red-black-tree "^1.0.1"
     mcl-wasm "^0.7.1"
-    merkle-patricia-tree "^4.1.0"
+    merkle-patricia-tree "^4.2.0"
     rustbn.js "~0.2.0"
     util.promisify "^1.0.1"
 
@@ -386,7 +386,7 @@
     "@ethersproject/properties" "^5.1.0"
     "@ethersproject/strings" "^5.1.0"
 
-"@ethersproject/abi@5.4.0", "@ethersproject/abi@^5.4.0":
+"@ethersproject/abi@5.4.0", "@ethersproject/abi@^5.1.2", "@ethersproject/abi@^5.4.0":
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.4.0.tgz#a6d63bdb3672f738398846d4279fa6b6c9818242"
   integrity sha512-9gU2H+/yK1j2eVMdzm6xvHSnMxk8waIHQGYCZg5uvAyH0rsAzxkModzBSpbAkAuhKFEovC2S9hM4nPuLym8IZw==
@@ -1265,6 +1265,10 @@
     "@keep-network/sortition-pools" ">1.2.0-pre <1.2.0-rc"
     "@openzeppelin/upgrades" "^2.7.2"
     openzeppelin-solidity "2.3.0"
+
+"@keep-network/prettier-config-keep@github:keep-network/prettier-config-keep":
+  version "0.0.1"
+  resolved "https://codeload.github.com/keep-network/prettier-config-keep/tar.gz/a1a333e7ac49928a0f6ed39421906dd1e46ab0f3"
 
 "@keep-network/prettier-config-keep@github:keep-network/prettier-config-keep#d6ec02e":
   version "0.0.1"
@@ -4503,7 +4507,7 @@ eslint-config-google@^0.13.0:
     eslint-plugin-no-only-tests "^2.3.1"
     eslint-plugin-prettier "^3.1.2"
 
-eslint-config-prettier@^6.10.0:
+eslint-config-prettier@^6.15.0:
   version "6.15.0"
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.15.0.tgz#7f93f6cb7d45a92f1537a70ecc06366e1ac6fed9"
   integrity sha512-a1+kOYLR8wMGustcgAjdydMsQ2A/2ipRPwRKUmfYaSxc9ZPcrku080Ctl6zrZzZNs/U82MjSv+qKREkoq3bJaw==
@@ -5086,10 +5090,22 @@ ethereumjs-util@^5.0.0, ethereumjs-util@^5.0.1, ethereumjs-util@^5.1.1, ethereum
     rlp "^2.0.0"
     safe-buffer "^5.1.1"
 
-ethereumjs-util@^7.0.10, ethereumjs-util@^7.0.2, ethereumjs-util@^7.0.7, ethereumjs-util@^7.0.8, ethereumjs-util@^7.0.9:
+ethereumjs-util@^7.0.2, ethereumjs-util@^7.0.7:
   version "7.0.10"
   resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-7.0.10.tgz#5fb7b69fa1fda0acc59634cf39d6b0291180fc1f"
   integrity sha512-c/xThw6A+EAnej5Xk5kOzFzyoSnw0WX0tSlZ6pAsfGVvQj3TItaDg9b1+Fz1RJXA+y2YksKwQnuzgt1eY6LKzw==
+  dependencies:
+    "@types/bn.js" "^5.1.0"
+    bn.js "^5.1.2"
+    create-hash "^1.1.2"
+    ethereum-cryptography "^0.1.3"
+    ethjs-util "0.1.6"
+    rlp "^2.2.4"
+
+ethereumjs-util@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-7.1.0.tgz#e2b43a30bfcdbcb432a4eb42bd5f2393209b3fd5"
+  integrity sha512-kR+vhu++mUDARrsMMhsjjzPduRVAeundLGXucGRHF3B4oEltOUspfgCVco4kckucj3FMlLaZHUl9n7/kdmr6Tw==
   dependencies:
     "@types/bn.js" "^5.1.0"
     bn.js "^5.1.2"
@@ -6195,16 +6211,17 @@ hardhat-gas-reporter@^1.0.4:
     eth-gas-reporter "^0.2.20"
     sha1 "^1.1.1"
 
-hardhat@^2.1.1:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/hardhat/-/hardhat-2.2.0.tgz#7d569d29678e5f786a228390b4c0b0cc9fd8ae32"
-  integrity sha512-3g0qFoQTkR4gfcHDZr59vPfbSH2PiAyxzYblkAAHUNTPBadO5W26z5RWzDv6/lRu8SqZZ9/8AdGZX4IZEa8EDg==
+hardhat@^2.2.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/hardhat/-/hardhat-2.6.1.tgz#4553ca555c1ba8ed7c3c5a5a93e6082a2869b3ae"
+  integrity sha512-0LozdYbPsiTc6ZXsfDQUTV3L0p4CMO5TRbd5qmeWiCYGmhd+7Mvdg4N+nA8w0g3gZ2OKFUmHIYlAbExI488ceQ==
   dependencies:
-    "@ethereumjs/block" "^3.2.1"
-    "@ethereumjs/blockchain" "^5.2.1"
-    "@ethereumjs/common" "^2.2.0"
-    "@ethereumjs/tx" "^3.1.3"
-    "@ethereumjs/vm" "^5.3.2"
+    "@ethereumjs/block" "^3.4.0"
+    "@ethereumjs/blockchain" "^5.4.0"
+    "@ethereumjs/common" "^2.4.0"
+    "@ethereumjs/tx" "^3.3.0"
+    "@ethereumjs/vm" "^5.5.2"
+    "@ethersproject/abi" "^5.1.2"
     "@sentry/node" "^5.18.1"
     "@solidity-parser/parser" "^0.11.0"
     "@types/bn.js" "^5.1.0"
@@ -6221,15 +6238,16 @@ hardhat@^2.1.1:
     eth-sig-util "^2.5.2"
     ethereum-cryptography "^0.1.2"
     ethereumjs-abi "^0.6.8"
-    ethereumjs-util "^7.0.10"
+    ethereumjs-util "^7.1.0"
     find-up "^2.1.0"
     fp-ts "1.19.3"
     fs-extra "^7.0.1"
     glob "^7.1.3"
+    https-proxy-agent "^5.0.0"
     immutable "^4.0.0-rc.12"
     io-ts "1.10.4"
     lodash "^4.17.11"
-    merkle-patricia-tree "^4.1.0"
+    merkle-patricia-tree "^4.2.0"
     mnemonist "^0.38.0"
     mocha "^7.1.2"
     node-fetch "^2.6.0"
@@ -6244,7 +6262,7 @@ hardhat@^2.1.1:
     "true-case-path" "^2.2.1"
     tsort "0.0.1"
     uuid "^3.3.2"
-    ws "^7.2.1"
+    ws "^7.4.6"
 
 has-ansi@^2.0.0:
   version "2.0.0"
@@ -7724,17 +7742,17 @@ merkle-patricia-tree@^2.1.2, merkle-patricia-tree@^2.3.2:
     rlp "^2.0.0"
     semaphore ">=1.0.1"
 
-merkle-patricia-tree@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/merkle-patricia-tree/-/merkle-patricia-tree-4.1.0.tgz#010636c4cfd68682df33a2e3186b7d0be7b98b9d"
-  integrity sha512-vmP1J7FwIpprFMVjjSMM1JAwFce85Q+tp0TYIedYv8qaMh2oLUZ3ETXn9wbgi9S6elySzKzGa+Ai6VNKGEwSlg==
+merkle-patricia-tree@^4.2.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/merkle-patricia-tree/-/merkle-patricia-tree-4.2.1.tgz#fc43e7b162e597a0720ccdd702bf1d49765691d2"
+  integrity sha512-25reMgrT8PhJy0Ba0U7fMZD2oobS1FPWB9vQa0uBpJYIQYYuFXEHoqEkTqA/UzX+s9br3pmUVVY/TOsFt/x0oQ==
   dependencies:
     "@types/levelup" "^4.3.0"
-    ethereumjs-util "^7.0.8"
+    ethereumjs-util "^7.1.0"
     level-mem "^5.0.1"
     level-ws "^2.0.0"
     readable-stream "^3.6.0"
-    rlp "^2.2.3"
+    rlp "^2.2.4"
     semaphore-async-await "^1.5.1"
 
 methods@~1.1.2:
@@ -12275,10 +12293,10 @@ ws@^5.1.1:
   dependencies:
     async-limiter "~1.0.0"
 
-ws@^7.2.1:
-  version "7.4.5"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.5.tgz#a484dd851e9beb6fdb420027e3885e8ce48986c1"
-  integrity sha512-xzyu3hFvomRfXKH8vOFMU3OguG6oOvhXMo3xsGy3xWExqaM2dxBbVxuD99O7m3ZUFMvvscsZDqxfgMaRr/Nr1g==
+ws@^7.4.6:
+  version "7.5.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.3.tgz#160835b63c7d97bfab418fc1b8a9fced2ac01a74"
+  integrity sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==
 
 xhr-request-promise@^0.1.2:
   version "0.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6211,7 +6211,7 @@ hardhat-gas-reporter@^1.0.4:
     eth-gas-reporter "^0.2.20"
     sha1 "^1.1.1"
 
-hardhat@2.6.1:
+hardhat@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/hardhat/-/hardhat-2.6.1.tgz#4553ca555c1ba8ed7c3c5a5a93e6082a2869b3ae"
   integrity sha512-0LozdYbPsiTc6ZXsfDQUTV3L0p4CMO5TRbd5qmeWiCYGmhd+7Mvdg4N+nA8w0g3gZ2OKFUmHIYlAbExI488ceQ==


### PR DESCRIPTION
Due to an [error](https://github.com/nomiclabs/hardhat/issues/1415) in Hardhat `2.2.0`, we decided to update Hardhat version and fix errors in unit and system tests.

The errors in tests were caused by functions like `isOpen`, `takeOffer`, `earlyClose` being called on auctions that self destructed (the previously used version of Hardhat seemed to tolerate such calls).

This PR contains the following changes:
- updates hardhat requirement from `^2.1.1` to `^2.2.1` (it seems `npm` installed the newest version -  `2.6.1`)
- adds helper function `isCodeAt(address)` which checks whether an address stores contract  code, which seems to be [the best way to check if contract self-destructed](https://ethereum.stackexchange.com/a/83024)
- uses `isCodeAt` instead of calling `isOpen` for checking auction self-destruction or relying on reverts

Note: Unfortunately, in two system tests a significant increase of gas usage was observed.
Note: The contracts themselves were not modified by this PR. 
