### PR TITLE
Simplify price impact condition

### DIFF
--- a/contracts/SignerBondsUniswapV2.sol
+++ b/contracts/SignerBondsUniswapV2.sol
@@ -291,7 +291,7 @@ contract SignerBondsUniswapV2 is ISignerBondsSwapStrategy, Ownable {
 
         // Same as: priceImpact <= priceImpactLimit
         return
-            amount * BASIS_POINT_DIVISOR <=
+            amount * BASIS_POINTS_DIVISOR <=
             maxAllowedPriceImpact * collateralTokenReserve;
     }
 

--- a/contracts/SignerBondsUniswapV2.sol
+++ b/contracts/SignerBondsUniswapV2.sol
@@ -289,19 +289,10 @@ contract SignerBondsUniswapV2 is ISignerBondsSwapStrategy, Ownable {
         (uint256 reserve0, uint256 reserve1, ) = uniswapPair.getReserves();
         uint256 collateralTokenReserve = WETH == token0 ? reserve1 : reserve0;
 
-        // Calculate the price impact. Multiply it by the floating point
-        // divisor to avoid float number.
-        // slither-disable-next-line divide-before-multiply
-        uint256 priceImpact = (CoveragePoolConstants.FLOATING_POINT_DIVISOR *
-            amount) / collateralTokenReserve;
-
-        // Calculate the price impact limit. Multiply it by the floating point
-        // divisor to avoid float number and make it comparable with the
-        // swap's price impact.
-        uint256 priceImpactLimit = (CoveragePoolConstants
-        .FLOATING_POINT_DIVISOR * maxAllowedPriceImpact) / BASIS_POINTS_DIVISOR;
-
-        return priceImpact <= priceImpactLimit;
+        // Same as: priceImpact <= priceImpactLimit
+        return
+            amount * BASIS_POINT_DIVISOR <=
+            maxAllowedPriceImpact * collateralTokenReserve;
     }
 
     /// @notice Compute Uniswap v2 pair address.


### PR DESCRIPTION
Current expression can be written in a simpler way without rounding errors.