### PR TITLE
Prevent approving already approved swappers

### DIFF
--- a/contracts/SignerBondsUniswapV2.sol
+++ b/contracts/SignerBondsUniswapV2.sol
@@ -261,6 +261,10 @@ contract SignerBondsUniswapV2 is ISignerBondsSwapStrategy, Ownable {
     /// @dev Can be called only by the contract owner.
     /// @param swapper Swapper that will be approved
     function approveSwapper(address swapper) external onlyOwner {
+        require(
+            !approvedSwappers[swapper],
+            "Signer bonds swapper has been already approved"
+        );
         emit SignerBondsSwapperApproved(swapper);
         approvedSwappers[swapper] = true;
     }

--- a/test/SignerBondsUniswapV2.test.js
+++ b/test/SignerBondsUniswapV2.test.js
@@ -286,6 +286,14 @@ describe("SignerBondsUniswapV2", () => {
           .to.emit(signerBondsUniswapV2, "SignerBondsSwapperApproved")
           .withArgs(swapper.address)
       })
+
+      it("should revert in case the swapper is already approved", async () => {
+        await expect(
+          signerBondsUniswapV2
+            .connect(governance)
+            .approveSwapper(swapper.address)
+        ).to.be.revertedWith("Signer bonds swapper has been already approved")
+      })
     })
   })
 


### PR DESCRIPTION
This change should prevent emitting `SignerBondsSwapperApproved` in case swapper is already approved.