### PR TITLE
You cannot pass: minor post-audit fixes to risk manager approval/unapproval process

### DIFF
--- a/contracts/CoveragePool.sol
+++ b/contracts/CoveragePool.sol
@@ -122,6 +122,11 @@ contract CoveragePool is Ownable {
     /// @dev Can be called only by the contract owner.
     /// @param riskManager Risk manager that will be unapproved
     function unapproveRiskManager(address riskManager) external onlyOwner {
+        require(
+            riskManagerApprovalTimestamps[riskManager] > 0 ||
+                approvedRiskManagers[riskManager],
+            "Risk manager is neither approved nor with a pending approval"
+        );
         delete riskManagerApprovalTimestamps[riskManager];
         delete approvedRiskManagers[riskManager];
         /* solhint-disable-next-line not-rely-on-time */

--- a/contracts/CoveragePool.sol
+++ b/contracts/CoveragePool.sol
@@ -80,6 +80,11 @@ contract CoveragePool is Ownable {
             "approveFirstRiskManager instead"
         );
 
+        require(
+            !approvedRiskManagers[riskManager],
+            "Risk manager already approved"
+        );
+
         /* solhint-disable-next-line not-rely-on-time */
         riskManagerApprovalTimestamps[riskManager] = block.timestamp;
         /* solhint-disable-next-line not-rely-on-time */

--- a/test/CoveragePool.test.js
+++ b/test/CoveragePool.test.js
@@ -174,6 +174,16 @@ describe("CoveragePool", () => {
             )
           ).to.be.equal(governanceDelay)
         })
+
+        context("when called for already approved risk manager", () => {
+          it("should revert", async () => {
+            await expect(
+              coveragePool
+                .connect(governance)
+                .beginRiskManagerApproval(anotherRiskManager.address)
+            ).to.be.revertedWith("Risk manager already approved")
+          })
+        })
       }
     )
   })

--- a/test/CoveragePool.test.js
+++ b/test/CoveragePool.test.js
@@ -286,6 +286,18 @@ describe("CoveragePool", () => {
       })
     })
 
+    context("when called for unknown risk manager", () => {
+      it("should revert", async () => {
+        await expect(
+          coveragePool
+            .connect(governance)
+            .unapproveRiskManager(riskManager.address)
+        ).to.be.revertedWith(
+          "Risk manager is neither approved nor with a pending approval"
+        )
+      })
+    })
+
     context("when cancelling risk manager approval process", () => {
       beforeEach(async () => {
         await coveragePool


### PR DESCRIPTION
Two minor post-audit fixes:
- Do not let to approve already approved risk manager.
- Do not allow to unapprove unknown risk manager.

No security risk but for consistency, we should disallow it.