### PR TITLE
Renamed `auctionTaker` to `offerTaker` in Auctioneer contract

### DIFF
--- a/contracts/Auctioneer.sol
+++ b/contracts/Auctioneer.sol
@@ -42,7 +42,7 @@ contract Auctioneer is CloneFactory {
     );
     event AuctionOfferTaken(
         address indexed auction,
-        address indexed auctionTaker,
+        address indexed offerTaker,
         address tokenAccepted,
         uint256 amount,
         uint256 portionToSeize // This amount should be divided by FLOATING_POINT_DIVISOR
@@ -59,8 +59,8 @@ contract Auctioneer is CloneFactory {
     /// @dev This function is meant to be called from a cloned auction. It logs
     ///      "offer taken" and "auction closed" events, seizes funds, and cleans
     ///      up closed auctions.
-    /// @param auctionTaker    The address of the taker of the auction, who will
-    ///                        receive the pool's seized funds
+    /// @param offerTaker      The address of the taker of the auction offer,
+    ///                        who will receive the pool's seized funds
     /// @param tokenPaid       The token this auction is denominated in
     /// @param tokenAmountPaid The amount of the token the taker paid
     /// @param portionToSeize   The portion of the pool the taker won at auction.
@@ -68,7 +68,7 @@ contract Auctioneer is CloneFactory {
     ///                        to calculate how much of the pool should be set
     ///                        aside as the taker's winnings.
     function offerTaken(
-        address auctionTaker,
+        address offerTaker,
         IERC20 tokenPaid,
         uint256 tokenAmountPaid,
         uint256 portionToSeize
@@ -77,7 +77,7 @@ contract Auctioneer is CloneFactory {
 
         emit AuctionOfferTaken(
             msg.sender,
-            auctionTaker,
+            offerTaker,
             address(tokenPaid),
             tokenAmountPaid,
             portionToSeize
@@ -91,7 +91,7 @@ contract Auctioneer is CloneFactory {
         // defined in Auction.sol
         //
         //slither-disable-next-line reentrancy-no-eth,reentrancy-events,reentrancy-benign
-        coveragePool.seizeFunds(auctionTaker, portionToSeize);
+        coveragePool.seizeFunds(offerTaker, portionToSeize);
 
         if (auction.isOpen()) {
             onAuctionPartiallyFilled(auction);

--- a/test/Auctioneer.test.js
+++ b/test/Auctioneer.test.js
@@ -140,7 +140,7 @@ describe("Auctioneer", () => {
           let events = pastEvents(receipt1, auctioneer, "AuctionOfferTaken")
           expect(events.length).to.equal(1)
           expect(events[0].args["auction"]).to.equal(auctionAddress)
-          expect(events[0].args["auctionTaker"]).to.equal(bidder.address)
+          expect(events[0].args["offerTaker"]).to.equal(bidder.address)
           expect(events[0].args["tokenAccepted"]).to.equal(testToken.address)
           expect(events[0].args["amount"]).to.equal(amountPaidForAuction1)
           expect(events[0].args["portionToSeize"]).to.be.closeTo(
@@ -151,7 +151,7 @@ describe("Auctioneer", () => {
           events = pastEvents(receipt2, auctioneer, "AuctionOfferTaken")
           expect(events.length).to.equal(1)
           expect(events[0].args["auction"]).to.equal(auctionAddress)
-          expect(events[0].args["auctionTaker"]).to.equal(bidder.address)
+          expect(events[0].args["offerTaker"]).to.equal(bidder.address)
           expect(events[0].args["tokenAccepted"]).to.equal(testToken.address)
           expect(events[0].args["amount"]).to.equal(amountPaidForAuction2)
           expect(events[0].args["portionToSeize"]).to.be.closeTo(
@@ -211,7 +211,7 @@ describe("Auctioneer", () => {
         const events = pastEvents(receipt, auctioneer, "AuctionOfferTaken")
         expect(events.length).to.equal(1)
         expect(events[0].args["auction"]).to.equal(auctionAddress)
-        expect(events[0].args["auctionTaker"]).to.equal(bidder.address)
+        expect(events[0].args["offerTaker"]).to.equal(bidder.address)
         expect(events[0].args["tokenAccepted"]).to.equal(testToken.address)
         expect(events[0].args["amount"]).to.equal(amountPaidForAuction)
         expect(events[0].args["portionToSeize"]).to.be.closeTo(


### PR DESCRIPTION
The old name could be confusing given that we emit `AuctionOfferTaken` and
have `offerTaken` and `onOffer` functions.