### PR TITLE
Simplified `offerTaken` callback, removed `isOpen` function of `Auction`

### DIFF
--- a/contracts/Auction.sol
+++ b/contracts/Auction.sol
@@ -158,6 +158,9 @@ contract Auction is IAuction {
 
         self.amountOutstanding -= amountToTransfer;
 
+        //slither-disable-next-line incorrect-equality
+        bool isFullyFilled = self.amountOutstanding == 0;
+
         // inform auctioneer of proceeds and winner. the auctioneer seizes funds
         // from the collateral pool in the name of the winner, and controls all
         // proceeds
@@ -167,11 +170,12 @@ contract Auction is IAuction {
             msg.sender,
             self.tokenAccepted,
             amountToTransfer,
-            portionToSeize
+            portionToSeize,
+            isFullyFilled
         );
 
         //slither-disable-next-line incorrect-equality
-        if (self.amountOutstanding == 0) {
+        if (isFullyFilled) {
             harikari();
         }
     }
@@ -202,10 +206,6 @@ contract Auction is IAuction {
 
     function amountTransferred() external view returns (uint256) {
         return self.amountDesired - self.amountOutstanding;
-    }
-
-    function isOpen() external view returns (bool) {
-        return self.amountOutstanding > 0;
     }
 
     /// @dev Delete all storage and destroy the contract. Should only be called

--- a/test/Auction.test.js
+++ b/test/Auction.test.js
@@ -62,12 +62,6 @@ describe("Auction", () => {
     const auctionAmountDesired = to1e18(1) // ex. 1 TBTC
 
     context("when the auction has been initialized", () => {
-      it("should be opened", async () => {
-        auction = await createAuction(auctionAmountDesired, auctionLength)
-
-        expect(await auction.isOpen()).to.equal(true)
-      })
-
       it("should not be initialized again", async () => {
         auction = await createAuction(auctionAmountDesired, auctionLength)
 
@@ -151,10 +145,7 @@ describe("Auction", () => {
         // add 100sec
         await increaseTime(100)
 
-        // make sure auction did not self destruct
         expect(await isCodeAt(auction.address)).to.be.true
-
-        expect(await auction.isOpen()).to.be.equal(true)
       })
     })
 
@@ -165,11 +156,6 @@ describe("Auction", () => {
         auction = await createAuction(auctionAmountDesired, auctionLength)
 
         await increaseTime(24000)
-      })
-
-      it("should be opened", async () => {
-        expect(await isCodeAt(auction.address)).to.be.true
-        expect(await auction.isOpen()).to.be.equal(true)
       })
 
       it("should return a portion of a collateral pool", async () => {
@@ -522,9 +508,6 @@ describe("Auction", () => {
           // when auction ends and is partially filled, it should not self
           // destruct
           expect(await isCodeAt(auction.address)).to.be.true
-
-          // when auction ends and is partially filled, it should stay opened
-          expect(await auction.isOpen()).to.be.equal(true)
         })
       }
     )


### PR DESCRIPTION
~~Depends on #183~~

`isOpen` does not really makes sense given that it always returns true.
When auction is fully filled, it is getting destroyed so it is not
possible to call any function on it.

`offerTaken` was simplified so that another ping-pong call between
`Auctioneer` and `Auction` could get eliminated. Instead of calling
`isOpenFunction`, `Auctioneer` returns information if the `Auction` 
was fully filled as one of `offerTaken` function parameters.