### PR TITLE
Replacing tenderly-cli with hardhat-tenderly plugin

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Configure tenderly
         if: github.event.inputs.environment == 'ropsten'
         env:
-          TENDERLY_ACCESS_KEY: ${{ secrets.TENDERLY_ACCESS_KEY }}
+          TENDERLY_TOKEN: ${{ secrets.TENDERLY_TOKEN }}
         run: ./config_tenderly.sh
 
       - name: Deploy contracts

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -95,6 +95,12 @@ jobs:
             @keep-network/keep-core@${{ steps.upstream-builds-query.outputs.keep-core-contracts-version }} \
             @keep-network/tbtc@${{ steps.upstream-builds-query.outputs.tbtc-contracts-version }}
 
+      - name: Configure tenderly
+        if: github.event.inputs.environment == 'ropsten'
+        env:
+          TENDERLY_ACCESS_KEY: ${{ secrets.TENDERLY_ACCESS_KEY }}
+        run: ./config_tenderly.sh
+
       - name: Deploy contracts
         env:
           CHAIN_API_URL: ${{ secrets.KEEP_TEST_ETH_HOSTNAME_HTTP }}
@@ -108,17 +114,6 @@ jobs:
           environment: ${{ github.event.inputs.environment }}
           branch: ${{ github.ref }}
           commit: ${{ github.sha }}
-
-      - name: Push contracts to Tenderly
-        if: github.event.inputs.environment == 'ropsten'
-        uses: keep-network/tenderly-push-action@v1
-        continue-on-error: true
-        with:
-          tenderly-token: ${{ secrets.TENDERLY_TOKEN }}
-          tenderly-project: thesis/keep-test
-          eth-network-id: ${{ env.NETWORK_ID }}
-          github-project-name: coverage-pools
-          version-tag: ${{ steps.npm-version-bump.outputs.version }}
 
       - name: Publish to npm
         run: |

--- a/.hardhat/networks_TEMPLATE.ts
+++ b/.hardhat/networks_TEMPLATE.ts
@@ -11,11 +11,13 @@ const config: LocalNetworksConfig = {
       url: "url not set",
       from: "address not set",
       accounts: ["private key not set"],
+      tags: ["tenderly"],
     },
     mainnet: {
       url: "url not set",
       from: "address not set",
       accounts: ["private key not set"],
+      tags: ["tenderly"],
     },
   },
 }

--- a/config_tenderly.sh
+++ b/config_tenderly.sh
@@ -9,4 +9,4 @@ printf "${LOG_START}Configuring Tenderly...${LOG_END}"
 
 mkdir $HOME/.tenderly && touch $HOME/.tenderly/config.yaml
 
-echo access_key: ${TENDERLY_ACCESS_KEY} > $HOME/.tenderly/config.yaml
+echo access_key: ${TENDERLY_TOKEN} > $HOME/.tenderly/config.yaml

--- a/config_tenderly.sh
+++ b/config_tenderly.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+LOG_START='\n\e[1;36m' # new line + bold + color
+LOG_END='\n\e[0m'      # new line + reset color
+
+printf "${LOG_START}Configuring Tenderly...${LOG_END}"
+
+mkdir $HOME/.tenderly && touch $HOME/.tenderly/config.yaml
+
+echo access_key: ${TENDERLY_ACCESS_KEY} > $HOME/.tenderly/config.yaml

--- a/deploy/04_deploy_underwriter_token.ts
+++ b/deploy/04_deploy_underwriter_token.ts
@@ -11,12 +11,8 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     log: true,
   })
 
-  if (hre.network.name == "ropsten") {
-    await hre.tenderly.persistArtifacts({
-      name: "UnderwriterToken",
-      address: underwriterToken.address,
-    })
-
+  const tags = hre.network.config.tags
+  if (tags.includes("test") || tags.includes("mainnet")) {
     await hre.tenderly.verify({
       name: "UnderwriterToken",
       address: underwriterToken.address,

--- a/deploy/04_deploy_underwriter_token.ts
+++ b/deploy/04_deploy_underwriter_token.ts
@@ -5,11 +5,23 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { getNamedAccounts, deployments } = hre
   const { deployer } = await getNamedAccounts()
 
-  await deployments.deploy("UnderwriterToken", {
+  const underwriterToken = await deployments.deploy("UnderwriterToken", {
     from: deployer,
     args: ["covKEEP underwriter token", "covKEEP"],
     log: true,
   })
+
+  if (hre.network.name == "ropsten") {
+    await hre.tenderly.persistArtifacts({
+      name: "UnderwriterToken",
+      address: underwriterToken.address,
+    })
+
+    await hre.tenderly.verify({
+      name: "UnderwriterToken",
+      address: underwriterToken.address,
+    })
+  }
 }
 
 export default func

--- a/deploy/04_deploy_underwriter_token.ts
+++ b/deploy/04_deploy_underwriter_token.ts
@@ -11,8 +11,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     log: true,
   })
 
-  const tags = hre.network.config.tags
-  if (tags.includes("test") || tags.includes("mainnet")) {
+  if (hre.network.tags.tenderly) {
     await hre.tenderly.verify({
       name: "UnderwriterToken",
       address: underwriterToken.address,

--- a/deploy/05_deploy_asset_pool.ts
+++ b/deploy/05_deploy_asset_pool.ts
@@ -17,12 +17,8 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     log: true,
   })
 
-  if (hre.network.name == "ropsten") {
-    await hre.tenderly.persistArtifacts({
-      name: "AssetPool",
-      address: AssetPool.address,
-    })
-
+  const tags = hre.network.config.tags
+  if (tags.includes("test") || tags.includes("mainnet")) {
     await hre.tenderly.verify({
       name: "AssetPool",
       address: AssetPool.address,

--- a/deploy/05_deploy_asset_pool.ts
+++ b/deploy/05_deploy_asset_pool.ts
@@ -17,6 +17,18 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     log: true,
   })
 
+  if (hre.network.name == "ropsten") {
+    await hre.tenderly.persistArtifacts({
+      name: "AssetPool",
+      address: AssetPool.address,
+    })
+
+    await hre.tenderly.verify({
+      name: "AssetPool",
+      address: AssetPool.address,
+    })
+  }
+
   const rewardsPoolAddress = helpers.address.validate(
     await read("AssetPool", "rewardsPool")
   )

--- a/deploy/05_deploy_asset_pool.ts
+++ b/deploy/05_deploy_asset_pool.ts
@@ -17,8 +17,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     log: true,
   })
 
-  const tags = hre.network.config.tags
-  if (tags.includes("test") || tags.includes("mainnet")) {
+  if (hre.network.tags.tenderly) {
     await hre.tenderly.verify({
       name: "AssetPool",
       address: AssetPool.address,

--- a/deploy/06_deploy_coverage_pool.ts
+++ b/deploy/06_deploy_coverage_pool.ts
@@ -13,8 +13,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     log: true,
   })
 
-  const tags = hre.network.config.tags
-  if (tags.includes("test") || tags.includes("mainnet")) {
+  if (hre.network.tags.tenderly) {
     await hre.tenderly.verify({
       name: "CoveragePool",
       address: CoveragePool.address,

--- a/deploy/06_deploy_coverage_pool.ts
+++ b/deploy/06_deploy_coverage_pool.ts
@@ -13,6 +13,18 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     log: true,
   })
 
+  if (hre.network.name == "ropsten") {
+    await hre.tenderly.persistArtifacts({
+      name: "CoveragePool",
+      address: CoveragePool.address,
+    })
+
+    await hre.tenderly.verify({
+      name: "CoveragePool",
+      address: CoveragePool.address,
+    })
+  }
+
   await helpers.ownable.transferOwnership(
     "AssetPool",
     CoveragePool.address,

--- a/deploy/06_deploy_coverage_pool.ts
+++ b/deploy/06_deploy_coverage_pool.ts
@@ -13,12 +13,8 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     log: true,
   })
 
-  if (hre.network.name == "ropsten") {
-    await hre.tenderly.persistArtifacts({
-      name: "CoveragePool",
-      address: CoveragePool.address,
-    })
-
+  const tags = hre.network.config.tags
+  if (tags.includes("test") || tags.includes("mainnet")) {
     await hre.tenderly.verify({
       name: "CoveragePool",
       address: CoveragePool.address,

--- a/deploy/07_deploy_auction_bidder.ts
+++ b/deploy/07_deploy_auction_bidder.ts
@@ -13,12 +13,8 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     log: true,
   })
 
-  if (hre.network.name == "ropsten") {
-    await hre.tenderly.persistArtifacts({
-      name: "AuctionBidder",
-      address: auctionBidder.address,
-    })
-
+  const tags = hre.network.config.tags
+  if (tags.includes("test") || tags.includes("mainnet")) {
     await hre.tenderly.verify({
       name: "AuctionBidder",
       address: auctionBidder.address,

--- a/deploy/07_deploy_auction_bidder.ts
+++ b/deploy/07_deploy_auction_bidder.ts
@@ -7,11 +7,23 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
   const CoveragePool = await deployments.get("CoveragePool")
 
-  await deployments.deploy("AuctionBidder", {
+  const auctionBidder = await deployments.deploy("AuctionBidder", {
     from: deployer,
     args: [CoveragePool.address],
     log: true,
   })
+
+  if (hre.network.name == "ropsten") {
+    await hre.tenderly.persistArtifacts({
+      name: "AuctionBidder",
+      address: auctionBidder.address,
+    })
+
+    await hre.tenderly.verify({
+      name: "AuctionBidder",
+      address: auctionBidder.address,
+    })
+  }
 }
 
 export default func

--- a/deploy/07_deploy_auction_bidder.ts
+++ b/deploy/07_deploy_auction_bidder.ts
@@ -13,8 +13,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     log: true,
   })
 
-  const tags = hre.network.config.tags
-  if (tags.includes("test") || tags.includes("mainnet")) {
+  if (hre.network.tags.tenderly) {
     await hre.tenderly.verify({
       name: "AuctionBidder",
       address: auctionBidder.address,

--- a/deploy/08_deploy_signer_bonds_manual_swap.ts
+++ b/deploy/08_deploy_signer_bonds_manual_swap.ts
@@ -13,8 +13,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     }
   )
 
-  const tags = hre.network.config.tags
-  if (tags.includes("test") || tags.includes("mainnet")) {
+  if (hre.network.tags.tenderly) {
     await hre.tenderly.verify({
       name: "SignerBondsManualSwap",
       address: signerBondsManualSwap.address,

--- a/deploy/08_deploy_signer_bonds_manual_swap.ts
+++ b/deploy/08_deploy_signer_bonds_manual_swap.ts
@@ -5,10 +5,25 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { getNamedAccounts, deployments } = hre
   const { deployer } = await getNamedAccounts()
 
-  await deployments.deploy("SignerBondsManualSwap", {
-    from: deployer,
-    log: true,
-  })
+  const signerBondsManualSwap = await deployments.deploy(
+    "SignerBondsManualSwap",
+    {
+      from: deployer,
+      log: true,
+    }
+  )
+
+  if (hre.network.name == "ropsten") {
+    await hre.tenderly.persistArtifacts({
+      name: "SignerBondsManualSwap",
+      address: signerBondsManualSwap.address,
+    })
+
+    await hre.tenderly.verify({
+      name: "SignerBondsManualSwap",
+      address: signerBondsManualSwap.address,
+    })
+  }
 }
 
 export default func

--- a/deploy/08_deploy_signer_bonds_manual_swap.ts
+++ b/deploy/08_deploy_signer_bonds_manual_swap.ts
@@ -13,12 +13,8 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     }
   )
 
-  if (hre.network.name == "ropsten") {
-    await hre.tenderly.persistArtifacts({
-      name: "SignerBondsManualSwap",
-      address: signerBondsManualSwap.address,
-    })
-
+  const tags = hre.network.config.tags
+  if (tags.includes("test") || tags.includes("mainnet")) {
     await hre.tenderly.verify({
       name: "SignerBondsManualSwap",
       address: signerBondsManualSwap.address,

--- a/deploy/09_deploy_signer_bonds_uniswap_v2.ts
+++ b/deploy/09_deploy_signer_bonds_uniswap_v2.ts
@@ -17,12 +17,8 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     }
   )
 
-  if (hre.network.name == "ropsten") {
-    await hre.tenderly.persistArtifacts({
-      name: "SignerBondsUniswapV2",
-      address: signerBondsUniswapV2.address,
-    })
-
+  const tags = hre.network.config.tags
+  if (tags.includes("test") || tags.includes("mainnet")) {
     await hre.tenderly.verify({
       name: "SignerBondsUniswapV2",
       address: signerBondsUniswapV2.address,

--- a/deploy/09_deploy_signer_bonds_uniswap_v2.ts
+++ b/deploy/09_deploy_signer_bonds_uniswap_v2.ts
@@ -17,8 +17,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     }
   )
 
-  const tags = hre.network.config.tags
-  if (tags.includes("test") || tags.includes("mainnet")) {
+  if (hre.network.tags.tenderly) {
     await hre.tenderly.verify({
       name: "SignerBondsUniswapV2",
       address: signerBondsUniswapV2.address,

--- a/deploy/09_deploy_signer_bonds_uniswap_v2.ts
+++ b/deploy/09_deploy_signer_bonds_uniswap_v2.ts
@@ -8,11 +8,26 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const UniswapV2Router = await deployments.get("UniswapV2Router")
   const CoveragePool = await deployments.get("CoveragePool")
 
-  await deployments.deploy("SignerBondsUniswapV2", {
-    from: deployer,
-    args: [UniswapV2Router.address, CoveragePool.address],
-    log: true,
-  })
+  const signerBondsUniswapV2 = await deployments.deploy(
+    "SignerBondsUniswapV2",
+    {
+      from: deployer,
+      args: [UniswapV2Router.address, CoveragePool.address],
+      log: true,
+    }
+  )
+
+  if (hre.network.name == "ropsten") {
+    await hre.tenderly.persistArtifacts({
+      name: "SignerBondsUniswapV2",
+      address: signerBondsUniswapV2.address,
+    })
+
+    await hre.tenderly.verify({
+      name: "SignerBondsUniswapV2",
+      address: signerBondsUniswapV2.address,
+    })
+  }
 }
 
 export default func

--- a/deploy/10_deploy_master_auction.ts
+++ b/deploy/10_deploy_master_auction.ts
@@ -13,8 +13,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     log: true,
   })
 
-  const tags = hre.network.config.tags
-  if (tags.includes("test") || tags.includes("mainnet")) {
+  if (hre.network.tags.tenderly) {
     await hre.tenderly.verify({
       name: "Auction",
       address: Auction.address,

--- a/deploy/10_deploy_master_auction.ts
+++ b/deploy/10_deploy_master_auction.ts
@@ -13,12 +13,8 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     log: true,
   })
 
-  if (hre.network.name == "ropsten") {
-    await hre.tenderly.persistArtifacts({
-      name: "Auction",
-      address: Auction.address,
-    })
-
+  const tags = hre.network.config.tags
+  if (tags.includes("test") || tags.includes("mainnet")) {
     await hre.tenderly.verify({
       name: "Auction",
       address: Auction.address,

--- a/deploy/10_deploy_master_auction.ts
+++ b/deploy/10_deploy_master_auction.ts
@@ -7,11 +7,23 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
   // Deploy a master Auction contract that will be used by Auctioneer to create
   // clones instances.
-  await deployments.deploy("Auction", {
+  const Auction = await deployments.deploy("Auction", {
     contract: "Auction",
     from: deployer,
     log: true,
   })
+
+  if (hre.network.name == "ropsten") {
+    await hre.tenderly.persistArtifacts({
+      name: "Auction",
+      address: Auction.address,
+    })
+
+    await hre.tenderly.verify({
+      name: "Auction",
+      address: Auction.address,
+    })
+  }
 }
 
 export default func

--- a/deploy/11_deploy_risk_manager_v1.ts
+++ b/deploy/11_deploy_risk_manager_v1.ts
@@ -51,8 +51,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     log: true,
   })
 
-  const tags = hre.network.config.tags
-  if (tags.includes("test") || tags.includes("mainnet")) {
+  if (hre.network.tags.tenderly) {
     await hre.tenderly.verify({
       name: "RiskManagerV1",
       address: riskManagerV1.address,

--- a/deploy/11_deploy_risk_manager_v1.ts
+++ b/deploy/11_deploy_risk_manager_v1.ts
@@ -51,12 +51,8 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     log: true,
   })
 
-  if (hre.network.name == "ropsten") {
-    await hre.tenderly.persistArtifacts({
-      name: "RiskManagerV1",
-      address: riskManagerV1.address,
-    })
-
+  const tags = hre.network.config.tags
+  if (tags.includes("test") || tags.includes("mainnet")) {
     await hre.tenderly.verify({
       name: "RiskManagerV1",
       address: riskManagerV1.address,

--- a/deploy/11_deploy_risk_manager_v1.ts
+++ b/deploy/11_deploy_risk_manager_v1.ts
@@ -37,7 +37,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
       `as initial risk manager's swap strategy`
   )
 
-  await deployments.deploy("RiskManagerV1", {
+  const riskManagerV1 = await deployments.deploy("RiskManagerV1", {
     from: deployer,
     args: [
       TBTCToken.address,
@@ -50,6 +50,18 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     ],
     log: true,
   })
+
+  if (hre.network.name == "ropsten") {
+    await hre.tenderly.persistArtifacts({
+      name: "RiskManagerV1",
+      address: riskManagerV1.address,
+    })
+
+    await hre.tenderly.verify({
+      name: "RiskManagerV1",
+      address: riskManagerV1.address,
+    })
+  }
 }
 
 export default func

--- a/deploy/13_deploy_coverage_pool_beneficiary.ts
+++ b/deploy/13_deploy_coverage_pool_beneficiary.ts
@@ -21,6 +21,18 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     }
   )
 
+  if (hre.network.name == "ropsten") {
+    await hre.tenderly.persistArtifacts({
+      name: "CoveragePoolBeneficiary",
+      address: CoveragePoolBeneficiary.address,
+    })
+
+    await hre.tenderly.verify({
+      name: "CoveragePoolBeneficiary",
+      address: CoveragePoolBeneficiary.address,
+    })
+  }
+
   await helpers.ownable.transferOwnership(
     "CoveragePoolBeneficiary",
     BatchedPhasedEscrow.address,

--- a/deploy/13_deploy_coverage_pool_beneficiary.ts
+++ b/deploy/13_deploy_coverage_pool_beneficiary.ts
@@ -21,8 +21,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     }
   )
 
-  const tags = hre.network.config.tags
-  if (tags.includes("test") || tags.includes("mainnet")) {
+  if (hre.network.tags.tenderly) {
     await hre.tenderly.verify({
       name: "CoveragePoolBeneficiary",
       address: CoveragePoolBeneficiary.address,

--- a/deploy/13_deploy_coverage_pool_beneficiary.ts
+++ b/deploy/13_deploy_coverage_pool_beneficiary.ts
@@ -21,12 +21,8 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     }
   )
 
-  if (hre.network.name == "ropsten") {
-    await hre.tenderly.persistArtifacts({
-      name: "CoveragePoolBeneficiary",
-      address: CoveragePoolBeneficiary.address,
-    })
-
+  const tags = hre.network.config.tags
+  if (tags.includes("test") || tags.includes("mainnet")) {
     await hre.tenderly.verify({
       name: "CoveragePoolBeneficiary",
       address: CoveragePoolBeneficiary.address,

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -50,7 +50,7 @@ const config: HardhatUserConfig = {
   },
   tenderly: {
     username: "thesis",
-    project: "keep-test", // hardhat-tenderly plugin is used on ropsten only
+    project: "",
   },
   // // Define local networks configuration file path to load networks from the file.
   // localNetworksConfig: "./.hardhat/networks.ts",

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -45,6 +45,7 @@ const config: HardhatUserConfig = {
       accounts: process.env.CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY
         ? [process.env.CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY]
         : undefined,
+      tags: ["test"],
     },
   },
   tenderly: {

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -7,6 +7,7 @@ import "@nomiclabs/hardhat-ethers"
 import "hardhat-gas-reporter"
 import "hardhat-deploy"
 import "solidity-coverage"
+import "@tenderly/hardhat-tenderly"
 
 const config: HardhatUserConfig = {
   solidity: {
@@ -45,6 +46,10 @@ const config: HardhatUserConfig = {
         ? [process.env.CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY]
         : undefined,
     },
+  },
+  tenderly: {
+    username: "thesis",
+    project: "keep-test", // hardhat-tenderly plugin is used on ropsten only
   },
   // // Define local networks configuration file path to load networks from the file.
   // localNetworksConfig: "./.hardhat/networks.ts",

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -45,7 +45,7 @@ const config: HardhatUserConfig = {
       accounts: process.env.CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY
         ? [process.env.CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY]
         : undefined,
-      tags: ["test"],
+      tags: ["tenderly"],
     },
   },
   tenderly: {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "@keep-network/keep-core": ">1.8.0-dev <1.8.0-pre",
     "@keep-network/tbtc": ">1.1.2-dev <1.1.2-ropsten",
     "@thesis/solidity-contracts": "github:thesis/solidity-contracts#a1384af",
-    "@openzeppelin/contracts": "^4.1.0"
+    "@openzeppelin/contracts": "^4.1.0",
+    "@tenderly/hardhat-tenderly": "^1.0.12"
   },
   "devDependencies": {
     "@keep-network/hardhat-helpers": "^0.2.0-pre",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1647,6 +1647,15 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
+"@tenderly/hardhat-tenderly@^1.0.12":
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/@tenderly/hardhat-tenderly/-/hardhat-tenderly-1.0.12.tgz#fa64da2bf2f6d35a1c131ac9ccaf2f7e8b189a50"
+  integrity sha512-zx2zVpbBxGWVp+aLgf59sZR5lxdqfq/PjqUhga6+iazukQNu/Y6pLfVnCcF1ggvLsf7gnMjwLe3YEx/GxCAykQ==
+  dependencies:
+    axios "^0.21.1"
+    fs-extra "^9.0.1"
+    js-yaml "^3.14.0"
+
 "@thesis/solidity-contracts@github:thesis/solidity-contracts#a1384af":
   version "0.0.1"
   resolved "https://codeload.github.com/thesis/solidity-contracts/tar.gz/a1384afd039f0de4d698872b204a74337c15857f"
@@ -2358,6 +2367,11 @@ asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
+
+at-least-node@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
+  integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
 
 atob@^2.1.2:
   version "2.1.2"
@@ -5821,6 +5835,16 @@ fs-extra@^8.1.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
+fs-extra@^9.0.1:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
+  integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
+  dependencies:
+    at-least-node "^1.0.0"
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
+
 fs-minipass@^1.2.5:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.7.tgz#ccff8570841e7fe4265693da88936c55aed7f7c7"
@@ -7014,7 +7038,7 @@ js-yaml@3.13.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-js-yaml@3.x, js-yaml@^3.12.0, js-yaml@^3.13.0, js-yaml@^3.13.1:
+js-yaml@3.x, js-yaml@^3.12.0, js-yaml@^3.13.0, js-yaml@^3.13.1, js-yaml@^3.14.0:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
   integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==


### PR DESCRIPTION
Tenderly-cli cannot resolve the issue with compilation of different Solidity contracts that uses different pragmas. `Error during source code compiling`. We have dependency from OZ and other Keep-network related projects that used Solidity version other than 0.8.5
The workaround was to use `hardhat-tenderly` plugin to programatically push & verify contracts on Tenderly for Ropsten network. The caveat is that we'd need to look at the logs to see the address of deployed contract and move it to appropriate Tenderly project if needed. The logs would look similar to this:
```
deploying "UnderwriterToken" (tx: 0x9efeee9652b065fef1fa7bb59261dbe7583595cfd4f44f2569576fb42edae4cc)...: deployed at 0x1e83039A7F14D035Ec0De7CfD9044a24860Ce14A with 2455401 gas
Smart Contracts successfully verified
  Contract 0x1e83039a7f14d035ec0de7cfd9044a24860ce14a verified. You can view the contract at https://dashboard.tenderly.co/contract/ropsten/0x1e83039a7f14d035ec0de7cfd9044a24860ce14a
  ```