### PR TITLE
Update `WithdrawalCompleted` event

### DIFF
--- a/contracts/AssetPool.sol
+++ b/contracts/AssetPool.sol
@@ -85,6 +85,7 @@ contract AssetPool is Ownable, IAssetPool {
     event WithdrawalCompleted(
         address indexed underwriter,
         uint256 amount,
+        uint256 covAmount,
         uint256 timestamp
     );
 
@@ -296,6 +297,7 @@ contract AssetPool is Ownable, IAssetPool {
         emit WithdrawalCompleted(
             underwriter,
             amountToWithdraw,
+            covAmount,
             block.timestamp
         );
         collateralToken.safeTransfer(underwriter, amountToWithdraw);

--- a/contracts/AssetPool.sol
+++ b/contracts/AssetPool.sol
@@ -66,7 +66,7 @@ contract AssetPool is Ownable, IAssetPool {
     mapping(address => uint256) public pendingWithdrawal;
 
     event Deposited(
-        address indexed underwrtier,
+        address indexed underwriter,
         uint256 amount,
         uint256 covAmount
     );

--- a/test/AssetPool.test.js
+++ b/test/AssetPool.test.js
@@ -753,16 +753,22 @@ describe("AssetPool", () => {
         // We can approve the number of tokens equal to the number of tokens
         // deposited - there were no claims and no rewards were allocated so
         // those numbers are equal.
+        const covAmount = amount
         await underwriterToken
           .connect(underwriter1)
-          .approve(assetPool.address, amount)
-        await assetPool.connect(underwriter1).initiateWithdrawal(amount)
+          .approve(assetPool.address, covAmount)
+        await assetPool.connect(underwriter1).initiateWithdrawal(covAmount)
         await increaseTime(withdrawalDelay)
         const tx = await assetPool.completeWithdrawal(underwriter1.address)
 
-        expect(tx)
+        await expect(tx)
           .to.emit(assetPool, "WithdrawalCompleted")
-          .withArgs(underwriter1.address, amount, await lastBlockTime())
+          .withArgs(
+            underwriter1.address,
+            amount,
+            covAmount,
+            await lastBlockTime()
+          )
       })
 
       context("when no collateral tokens were claimed by the pool", () => {

--- a/test/AssetPool.test.js
+++ b/test/AssetPool.test.js
@@ -271,7 +271,7 @@ describe("AssetPool", () => {
       it("should emit Deposited event with correct covAmount", async () => {
         const events = pastEvents(await tx.wait(), assetPool, "Deposited")
         expect(events.length).to.equal(1)
-        expect(events[0].args["underwrtier"]).to.equal(underwriter2.address)
+        expect(events[0].args["underwriter"]).to.equal(underwriter2.address)
         expect(events[0].args["amount"]).to.equal(depositedUnderwriter2)
         expect(events[0].args["covAmount"]).to.be.closeTo(
           "45454545454545454545",


### PR DESCRIPTION
Add `covAmount` arg to `WithdrawalCompleted` event so there is no need
to subscribe to `Transfer` event of `underwriterToken` to detect burned
tokens- withdrawn cov tokens are burned. This might be helpful from the
dapp's/the Graph's perspective.