### PR TITLE
Adding cron for daily tests and builds on Mercode

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -1,6 +1,8 @@
 name: Solidity
 
 on:
+  schedule:
+    - cron: "0 0 * * *"
   push:
     branches:
       - main
@@ -46,6 +48,7 @@ jobs:
 
   contracts-deployment-dry-run:
     runs-on: ubuntu-latest
+    if: github.event_name != 'schedule'
     steps:
       - uses: actions/checkout@v2
 
@@ -139,7 +142,9 @@ jobs:
 
   contracts-lint:
     runs-on: ubuntu-latest
-    if: github.event_name != 'workflow_dispatch'
+    if: |
+      github.event_name != 'workflow_dispatch'
+        && github.event_name != 'schedule'
     steps:
       - uses: actions/checkout@v2
 
@@ -156,7 +161,9 @@ jobs:
 
   contracts-slither:
     runs-on: ubuntu-latest
-    if: github.event_name != 'workflow_dispatch'
+    if: |
+      github.event_name != 'workflow_dispatch'
+        && github.event_name != 'schedule'
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
The purpose of this PR is to set a cron job that would run tests and builds on a daily basis (at midnight) so the results can be displayed on Meercode dashboard.