### PR TITLE
Verify contracts on Etherscan [WIP]

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -102,43 +102,46 @@ jobs:
         env:
           CHAIN_API_URL: ${{ secrets.KEEP_TEST_ETH_HOSTNAME_HTTP }}
           CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: ${{ secrets.KEEP_TEST_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
+          ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
         run: yarn deploy --network ${{ github.event.inputs.environment }}
 
-      - name: Bump up package version
-        id: npm-version-bump
-        uses: keep-network/npm-version-bump@v2
-        with:
-          environment: ${{ github.event.inputs.environment }}
-          branch: ${{ github.ref }}
-          commit: ${{ github.sha }}
+      # TODO: uncomment before merging to main
+      
+      # - name: Bump up package version
+      #   id: npm-version-bump
+      #   uses: keep-network/npm-version-bump@v2
+      #   with:
+      #     environment: ${{ github.event.inputs.environment }}
+      #     branch: ${{ github.ref }}
+      #     commit: ${{ github.sha }}
 
-      - name: Push contracts to Tenderly
-        if: github.event.inputs.environment == 'ropsten'
-        uses: keep-network/tenderly-push-action@v1
-        continue-on-error: true
-        with:
-          tenderly-token: ${{ secrets.TENDERLY_TOKEN }}
-          tenderly-project: thesis/keep-test
-          eth-network-id: ${{ env.NETWORK_ID }}
-          github-project-name: coverage-pools
-          version-tag: ${{ steps.npm-version-bump.outputs.version }}
+      # - name: Push contracts to Tenderly
+      #   if: github.event.inputs.environment == 'ropsten'
+      #   uses: keep-network/tenderly-push-action@v1
+      #   continue-on-error: true
+      #   with:
+      #     tenderly-token: ${{ secrets.TENDERLY_TOKEN }}
+      #     tenderly-project: thesis/keep-test
+      #     eth-network-id: ${{ env.NETWORK_ID }}
+      #     github-project-name: coverage-pools
+      #     version-tag: ${{ steps.npm-version-bump.outputs.version }}
 
-      - name: Publish to npm
-        run: |
-          echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }} > .npmrc
-          npm publish --access=public --network=${{ github.event.inputs.environment }}
+      # - name: Publish to npm
+      #   run: |
+      #     echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }} > .npmrc
+      #     npm publish --access=public --network=${{ github.event.inputs.environment }}
 
-      - name: Notify CI about completion of the workflow
-        uses: keep-network/ci/actions/notify-workflow-completed@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
-        with:
-          module: "github.com/keep-network/coverage-pools"
-          url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          environment: ${{ github.event.inputs.environment }}
-          upstream_builds: ${{ github.event.inputs.upstream_builds }}
-          upstream_ref: ${{ github.event.inputs.upstream_ref }}
-          version: ${{ steps.npm-version-bump.outputs.version }}
+      # - name: Notify CI about completion of the workflow
+      #   uses: keep-network/ci/actions/notify-workflow-completed@v1
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
+      #   with:
+      #     module: "github.com/keep-network/coverage-pools"
+      #     url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      #     environment: ${{ github.event.inputs.environment }}
+      #     upstream_builds: ${{ github.event.inputs.upstream_builds }}
+      #     upstream_ref: ${{ github.event.inputs.upstream_ref }}
+      #     version: ${{ steps.npm-version-bump.outputs.version }}
 
   contracts-lint:
     runs-on: ubuntu-latest

--- a/deploy/04_deploy_underwriter_token.ts
+++ b/deploy/04_deploy_underwriter_token.ts
@@ -5,11 +5,24 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { getNamedAccounts, deployments } = hre
   const { deployer } = await getNamedAccounts()
 
-  await deployments.deploy("UnderwriterToken", {
+  const UnderwriterToken = await deployments.deploy("UnderwriterToken", {
     from: deployer,
     args: ["covKEEP underwriter token", "covKEEP"],
     log: true,
   })
+
+  if (hre.network.tags.etherscan) {
+    await hre.ethers.provider.waitForTransaction(UnderwriterToken.transactionHash, 10, 900000)
+
+    await hre.run("verify:verify", {
+      address: UnderwriterToken.address,
+      constructorArguments: [
+        "covKEEP underwriter token",
+        "covKEEP",
+      ],
+      contract: "contracts/UnderwriterToken.sol:UnderwriterToken",
+    })
+  }
 }
 
 export default func

--- a/deploy/05_deploy_asset_pool.ts
+++ b/deploy/05_deploy_asset_pool.ts
@@ -45,6 +45,20 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     AssetPool.address,
     deployer
   )
+
+  if (hre.network.tags.etherscan) {
+    await hre.ethers.provider.waitForTransaction(AssetPool.transactionHash, 10, 900000)
+
+    await hre.run("verify:verify", {
+      address: AssetPool.address,
+      constructorArguments: [
+        KeepToken.address,
+        UnderwriterToken.address,
+        rewardManager,
+      ],
+      contract: "contracts/AssetPool.sol:AssetPool",
+    })
+  }
 }
 
 export default func

--- a/deploy/06_deploy_coverage_pool.ts
+++ b/deploy/06_deploy_coverage_pool.ts
@@ -18,6 +18,18 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     CoveragePool.address,
     deployer
   )
+
+  if (hre.network.tags.etherscan) {
+    await hre.ethers.provider.waitForTransaction(CoveragePool.transactionHash, 10, 900000)
+
+    await hre.run("verify:verify", {
+      address: CoveragePool.address,
+      constructorArguments: [
+        AssetPool.address,
+      ],
+      contract: "contracts/CoveragePool.sol:CoveragePool",
+    })
+  }
 }
 
 export default func

--- a/deploy/07_deploy_auction_bidder.ts
+++ b/deploy/07_deploy_auction_bidder.ts
@@ -7,11 +7,23 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
   const CoveragePool = await deployments.get("CoveragePool")
 
-  await deployments.deploy("AuctionBidder", {
+  const AuctionBidder = await deployments.deploy("AuctionBidder", {
     from: deployer,
     args: [CoveragePool.address],
     log: true,
   })
+
+  if (hre.network.tags.etherscan) {
+    await hre.ethers.provider.waitForTransaction(AuctionBidder.transactionHash, 10, 900000)
+
+    await hre.run("verify:verify", {
+      address: AuctionBidder.address,
+      constructorArguments: [
+        CoveragePool.address,
+      ],
+      contract: "contracts/AuctionBidder.sol:AuctionBidder",
+    })
+  }
 }
 
 export default func

--- a/deploy/08_deploy_signer_bonds_manual_swap.ts
+++ b/deploy/08_deploy_signer_bonds_manual_swap.ts
@@ -5,10 +5,19 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { getNamedAccounts, deployments } = hre
   const { deployer } = await getNamedAccounts()
 
-  await deployments.deploy("SignerBondsManualSwap", {
+  const SignerBondsManualSwap = await deployments.deploy("SignerBondsManualSwap", {
     from: deployer,
     log: true,
   })
+
+  if (hre.network.tags.etherscan) {
+    await hre.ethers.provider.waitForTransaction(SignerBondsManualSwap.transactionHash, 10, 900000)
+
+    await hre.run("verify:verify", {
+      address: SignerBondsManualSwap.address,
+      contract: "contracts/SignerBondsManualSwap.sol:SignerBondsManualSwap",
+    })
+  }
 }
 
 export default func

--- a/deploy/09_deploy_signer_bonds_uniswap_v2.ts
+++ b/deploy/09_deploy_signer_bonds_uniswap_v2.ts
@@ -8,11 +8,24 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const UniswapV2Router = await deployments.get("UniswapV2Router")
   const CoveragePool = await deployments.get("CoveragePool")
 
-  await deployments.deploy("SignerBondsUniswapV2", {
+  const SignerBondsUniswapV2 = await deployments.deploy("SignerBondsUniswapV2", {
     from: deployer,
     args: [UniswapV2Router.address, CoveragePool.address],
     log: true,
   })
+
+  if (hre.network.tags.etherscan) {
+    await hre.ethers.provider.waitForTransaction(SignerBondsUniswapV2.transactionHash, 10, 900000)
+
+    await hre.run("verify:verify", {
+      address: SignerBondsUniswapV2.address,
+      constructorArguments: [
+        UniswapV2Router.address,
+        CoveragePool.address,
+      ],
+      contract: "contracts/SignerBondsUniswapV2.sol:SignerBondsUniswapV2",
+    })
+  }
 }
 
 export default func

--- a/deploy/10_deploy_master_auction.ts
+++ b/deploy/10_deploy_master_auction.ts
@@ -7,11 +7,20 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
   // Deploy a master Auction contract that will be used by Auctioneer to create
   // clones instances.
-  await deployments.deploy("Auction", {
+  const Auction = await deployments.deploy("Auction", {
     contract: "Auction",
     from: deployer,
     log: true,
   })
+
+  if (hre.network.tags.etherscan) {
+    await hre.ethers.provider.waitForTransaction(Auction.transactionHash, 10, 900000)
+
+    await hre.run("verify:verify", {
+      address: Auction.address,
+      contract: "contracts/Auction.sol:Auction",
+    })
+  }
 }
 
 export default func

--- a/deploy/11_deploy_risk_manager_v1.ts
+++ b/deploy/11_deploy_risk_manager_v1.ts
@@ -37,7 +37,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
       `as initial risk manager's swap strategy`
   )
 
-  await deployments.deploy("RiskManagerV1", {
+  const RiskManagerV1 = await deployments.deploy("RiskManagerV1", {
     from: deployer,
     args: [
       TBTCToken.address,
@@ -50,6 +50,24 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     ],
     log: true,
   })
+
+  if (hre.network.tags.etherscan) {
+    await hre.ethers.provider.waitForTransaction(RiskManagerV1.transactionHash, 10, 900000)
+
+    await hre.run("verify:verify", {
+      address: RiskManagerV1.address,
+      constructorArguments: [
+        TBTCToken.address,
+        TBTCDepositToken.address,
+        CoveragePool.address,
+        signerBondStrategy.address,
+        MasterAuction.address,
+        auctionLength,
+        bondAuctionThreshold,
+      ],
+      contract: "contracts/RiskManagerV1.sol:RiskManagerV1",
+    })
+  }
 }
 
 export default func

--- a/deploy/13_deploy_coverage_pool_beneficiary.ts
+++ b/deploy/13_deploy_coverage_pool_beneficiary.ts
@@ -32,6 +32,19 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     CoveragePoolBeneficiary.address,
     rewardManager
   )
+
+  if (hre.network.tags.etherscan) {
+    await hre.ethers.provider.waitForTransaction(CoveragePoolBeneficiary.transactionHash, 10, 900000)
+
+    await hre.run("verify:verify", {
+      address: CoveragePoolBeneficiary.address,
+      constructorArguments: [
+        KeepToken.address,
+        RewardsPoolAddress,
+      ],
+      contract: "contracts/CoveragePoolBeneficiary.sol:CoveragePoolBeneficiary",
+    })
+  }
 }
 
 export default func

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -2,6 +2,7 @@ import { HardhatUserConfig } from "hardhat/config"
 
 import "@keep-network/hardhat-helpers"
 import "@keep-network/hardhat-local-networks-config"
+import "@nomiclabs/hardhat-etherscan"
 import "@nomiclabs/hardhat-waffle"
 import "@nomiclabs/hardhat-ethers"
 import "hardhat-gas-reporter"
@@ -44,7 +45,11 @@ const config: HardhatUserConfig = {
       accounts: process.env.CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY
         ? [process.env.CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY]
         : undefined,
+      tags: ["etherscan"],
     },
+  },
+  etherscan: {
+    apiKey: process.env.ETHERSCAN_API_KEY
   },
   // // Define local networks configuration file path to load networks from the file.
   // localNetworksConfig: "./.hardhat/networks.ts",

--- a/package.json
+++ b/package.json
@@ -28,14 +28,15 @@
   "dependencies": {
     "@keep-network/keep-core": ">1.8.0-dev <1.8.0-pre",
     "@keep-network/tbtc": ">1.1.2-dev <1.1.2-ropsten",
-    "@thesis/solidity-contracts": "github:thesis/solidity-contracts#a1384af",
-    "@openzeppelin/contracts": "^4.1.0"
+    "@openzeppelin/contracts": "^4.1.0",
+    "@thesis/solidity-contracts": "github:thesis/solidity-contracts#a1384af"
   },
   "devDependencies": {
     "@keep-network/hardhat-helpers": "^0.2.0-pre",
     "@keep-network/hardhat-local-networks-config": "0.1.0-pre.0",
     "@keep-network/prettier-config-keep": "github:keep-network/prettier-config-keep#d6ec02e",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
+    "@nomiclabs/hardhat-etherscan": "^2.1.6",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@types/chai": "^4.2.20",
     "@types/mocha": "^8.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -475,7 +475,7 @@
     "@ethersproject/logger" "^5.1.0"
     "@ethersproject/rlp" "^5.1.0"
 
-"@ethersproject/address@5.4.0", "@ethersproject/address@^5.0.4", "@ethersproject/address@^5.3.0", "@ethersproject/address@^5.4.0":
+"@ethersproject/address@5.4.0", "@ethersproject/address@^5.0.2", "@ethersproject/address@^5.0.4", "@ethersproject/address@^5.3.0", "@ethersproject/address@^5.4.0":
   version "5.4.0"
   resolved "https://registry.npmjs.org/@ethersproject/address/-/address-5.4.0.tgz#ba2d00a0f8c4c0854933b963b9a3a9f6eb4a37a3"
   integrity sha512-SD0VgOEkcACEG/C6xavlU1Hy3m5DGSXW3CUHkaaEHbAPPsgi0coP5oNPsxau8eTlZOk/bpa/hKeCNoK5IzVI2Q==
@@ -1365,6 +1365,19 @@
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@nomiclabs/hardhat-ethers/-/hardhat-ethers-2.0.2.tgz#c472abcba0c5185aaa4ad4070146e95213c68511"
   integrity sha512-6quxWe8wwS4X5v3Au8q1jOvXYEPkS1Fh+cME5u6AwNdnI4uERvPlVjlgRWzpnb+Rrt1l/cEqiNRH9GlsBMSDQg==
+
+"@nomiclabs/hardhat-etherscan@^2.1.6":
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/@nomiclabs/hardhat-etherscan/-/hardhat-etherscan-2.1.6.tgz#8d1502f42adc6f7b8ef16fb917c0b5a8780cb83a"
+  integrity sha512-gCvT5fj8GbXS9+ACS3BzrX0pzYHHZqAHCb+NcipOkl2cy48FakUXlzrCf4P4sTH+Y7W10OgT62ezD1sJ+/NikQ==
+  dependencies:
+    "@ethersproject/abi" "^5.1.2"
+    "@ethersproject/address" "^5.0.2"
+    cbor "^5.0.2"
+    debug "^4.1.1"
+    fs-extra "^7.0.1"
+    node-fetch "^2.6.0"
+    semver "^6.3.0"
 
 "@nomiclabs/hardhat-waffle@^2.0.1":
   version "2.0.1"
@@ -3423,6 +3436,14 @@ cbor@^4.1.5:
     commander "^3.0.0"
     json-text-sequence "^0.1"
     nofilter "^1.0.3"
+
+cbor@^5.0.2:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/cbor/-/cbor-5.2.0.tgz#4cca67783ccd6de7b50ab4ed62636712f287a67c"
+  integrity sha512-5IMhi9e1QU76ppa5/ajP1BmMWZ2FHkhAhjeVKQ/EFCgYSEaeVaoGtL7cxJskf9oCCk+XjzaIdc3IuU/dbA/o2A==
+  dependencies:
+    bignumber.js "^9.0.1"
+    nofilter "^1.0.4"
 
 chai@^4.2.0, chai@^4.3.4:
   version "4.3.4"
@@ -8168,7 +8189,7 @@ node-gyp-build@^4.2.0:
   resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.2.3.tgz#ce6277f853835f718829efb47db20f3e4d9c4739"
   integrity sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==
 
-nofilter@^1.0.3:
+nofilter@^1.0.3, nofilter@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/nofilter/-/nofilter-1.0.4.tgz#78d6f4b6a613e7ced8b015cec534625f7667006e"
   integrity sha512-N8lidFp+fCz+TD51+haYdbDGrcBWwuHX40F5+z0qkUjMJ5Tp+rdSuAkMJ9N9eoolDlEVTf6u5icM+cNKkKW2mA==


### PR DESCRIPTION
We're adding steps veryfiing migrated contracts on Etherscan. Steps are
added to the deployment scripts. Verification is done using the
`@nomiclabs/hardhat-ethers` hardhat plugin. After the deployment steps
we wait with the verification for 5 confirmations of contract deployment
transaction in order to give the deployment time to propagate to the
backend.