### PR TITLE
Improvements to deployments and version bump to 1.1.0-dev

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -44,4 +44,4 @@ jobs:
       - name: Publish package
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access=public --network=hardhat
+        run: npm publish --access=public --network=hardhat --tag=development

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,4 @@ build/
 cache/
 deployments/
 typechain/
+export.json

--- a/deploy/00_resolve_keep_token.ts
+++ b/deploy/00_resolve_keep_token.ts
@@ -12,7 +12,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     log(`using external KeepToken at ${KeepToken.address}`)
   } else if (
     hre.network.name !== "hardhat" ||
-    (hre.network.config as HardhatNetworkConfig).forking.enabled == true
+    (hre.network.config as HardhatNetworkConfig).forking.enabled
   ) {
     throw new Error("deployed KeepToken contract not found")
   } else {

--- a/deploy/00_resolve_keep_token.ts
+++ b/deploy/00_resolve_keep_token.ts
@@ -1,4 +1,4 @@
-import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { HardhatRuntimeEnvironment, HardhatNetworkConfig } from "hardhat/types"
 import { DeployFunction } from "hardhat-deploy/types"
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
@@ -10,7 +10,10 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
   if (KeepToken && helpers.address.isValid(KeepToken.address)) {
     log(`using external KeepToken at ${KeepToken.address}`)
-  } else if (hre.network.name !== "hardhat") {
+  } else if (
+    hre.network.name !== "hardhat" ||
+    (hre.network.config as HardhatNetworkConfig).forking.enabled == true
+  ) {
     throw new Error("deployed KeepToken contract not found")
   } else {
     log(`deploying KeepToken stub`)

--- a/deploy/01_resolve_tbtc_token.ts
+++ b/deploy/01_resolve_tbtc_token.ts
@@ -1,4 +1,4 @@
-import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { HardhatRuntimeEnvironment, HardhatNetworkConfig } from "hardhat/types"
 import { DeployFunction } from "hardhat-deploy/types"
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
@@ -10,7 +10,10 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
   if (TBTCToken && helpers.address.isValid(TBTCToken.address)) {
     log(`using external TBTCToken at ${TBTCToken.address}`)
-  } else if (hre.network.name !== "hardhat") {
+  } else if (
+    hre.network.name !== "hardhat" ||
+    (hre.network.config as HardhatNetworkConfig).forking.enabled == true
+  ) {
     throw new Error("deployed TBTCToken contract not found")
   } else {
     log(`deploying TBTCToken stub`)

--- a/deploy/01_resolve_tbtc_token.ts
+++ b/deploy/01_resolve_tbtc_token.ts
@@ -12,7 +12,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     log(`using external TBTCToken at ${TBTCToken.address}`)
   } else if (
     hre.network.name !== "hardhat" ||
-    (hre.network.config as HardhatNetworkConfig).forking.enabled == true
+    (hre.network.config as HardhatNetworkConfig).forking.enabled
   ) {
     throw new Error("deployed TBTCToken contract not found")
   } else {

--- a/deploy/02_resolve_tdt_token.ts
+++ b/deploy/02_resolve_tdt_token.ts
@@ -12,7 +12,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     log(`using external TBTCDepositToken at ${TBTCDepositToken.address}`)
   } else if (
     hre.network.name !== "hardhat" ||
-    (hre.network.config as HardhatNetworkConfig).forking.enabled == true
+    (hre.network.config as HardhatNetworkConfig).forking.enabled
   ) {
     throw new Error("deployed TBTCDepositToken contract not found")
   } else {

--- a/deploy/02_resolve_tdt_token.ts
+++ b/deploy/02_resolve_tdt_token.ts
@@ -1,4 +1,4 @@
-import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { HardhatRuntimeEnvironment, HardhatNetworkConfig } from "hardhat/types"
 import { DeployFunction } from "hardhat-deploy/types"
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
@@ -10,7 +10,10 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
   if (TBTCDepositToken && helpers.address.isValid(TBTCDepositToken.address)) {
     log(`using external TBTCDepositToken at ${TBTCDepositToken.address}`)
-  } else if (hre.network.name !== "hardhat") {
+  } else if (
+    hre.network.name !== "hardhat" ||
+    (hre.network.config as HardhatNetworkConfig).forking.enabled == true
+  ) {
     throw new Error("deployed TBTCDepositToken contract not found")
   } else {
     log(`deploying TBTCDepositToken stub`)

--- a/deploy/03_resolve_uniswap_v2_router.ts
+++ b/deploy/03_resolve_uniswap_v2_router.ts
@@ -1,4 +1,4 @@
-import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { HardhatRuntimeEnvironment, HardhatNetworkConfig } from "hardhat/types"
 import { DeployFunction } from "hardhat-deploy/types"
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
@@ -10,7 +10,10 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
   if (UniswapV2Router && helpers.address.isValid(UniswapV2Router.address)) {
     log(`using external UniswapV2Router at ${UniswapV2Router.address}`)
-  } else if (!hre.network.tags.local) {
+  } else if (
+    hre.network.name !== "hardhat" ||
+    (hre.network.config as HardhatNetworkConfig).forking.enabled == true
+  ) {
     throw new Error("deployed UniswapV2Router contract not found")
   } else {
     // For any network tagged as `local` we want to deploy a stub if external

--- a/deploy/03_resolve_uniswap_v2_router.ts
+++ b/deploy/03_resolve_uniswap_v2_router.ts
@@ -12,7 +12,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     log(`using external UniswapV2Router at ${UniswapV2Router.address}`)
   } else if (
     hre.network.name !== "hardhat" ||
-    (hre.network.config as HardhatNetworkConfig).forking.enabled == true
+    (hre.network.config as HardhatNetworkConfig).forking.enabled
   ) {
     throw new Error("deployed UniswapV2Router contract not found")
   } else {

--- a/deploy/09_deploy_signer_bonds_uniswap_v2.ts
+++ b/deploy/09_deploy_signer_bonds_uniswap_v2.ts
@@ -17,6 +17,12 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     }
   )
 
+  const uniswapPair = await deployments.read(
+    "SignerBondsUniswapV2",
+    "uniswapPair"
+  )
+  console.log(`expected uniswap pair address: ${uniswapPair}`)
+
   if (hre.network.tags.tenderly) {
     await hre.tenderly.verify({
       name: "SignerBondsUniswapV2",

--- a/deploy/10_deploy_master_auction.ts
+++ b/deploy/10_deploy_master_auction.ts
@@ -23,4 +23,4 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
 export default func
 
-func.tags = ["MasterAuction"]
+func.tags = ["Auction"]

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -66,6 +66,9 @@ const config: HardhatUserConfig = {
       },
     ],
     deployments: {
+      // For hardhat environment we can fork the mainnet, so we need to point it
+      // to the contract artifacts.
+      hardhat: ["./external/mainnet"],
       // For development environment we expect the local dependencies to be linked
       // with `yarn link` command.
       development: [

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -96,6 +96,9 @@ const config: HardhatUserConfig = {
   mocha: {
     timeout: 30000,
   },
+  etherscan: {
+    apiKey: "PUT API KEY HERE",
+  },
 }
 
 export default config

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -68,7 +68,7 @@ const config: HardhatUserConfig = {
     deployments: {
       // For hardhat environment we can fork the mainnet, so we need to point it
       // to the contract artifacts.
-      hardhat: ["./external/mainnet"],
+      // hardhat: ["./external/mainnet"],
       // For development environment we expect the local dependencies to be linked
       // with `yarn link` command.
       development: [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@keep-network/coverage-pools",
   "version": "1.1.0-dev",
+  "license": "MIT",
   "files": [
     "artifacts/",
     "build/contracts/",
@@ -9,6 +10,14 @@
     "deploy/",
     "export.json"
   ],
+  "repository": {
+    "type": "git",
+    "url": "ssh://git@github.com/keep-network/coverage-pools"
+  },
+  "bugs": {
+    "url": "https://github.com/keep-network/coverage-pools/issues"
+  },
+  "homepage": "https://github.com/keep-network/coverage-pools",
   "scripts": {
     "build": "hardhat compile",
     "deploy": "hardhat deploy --export export.json",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/coverage-pools",
-  "version": "0.0.1-dev",
+  "version": "1.1.0-dev",
   "files": [
     "artifacts/",
     "build/contracts/",


### PR DESCRIPTION
Some of the changes in this PR are:

1. Version bump up after solidity/v1.0.0 release.
2. We want to tag the package so it's easier to use it in other projects for development. Also, we don't want to tag this package as default `latest`, as we want to reserve the `latest` tag for mainnet packages.
3. Improve deploy scripts for mainnet forking.
4. Added properties to package.json that are nice to have to display the package in npmjs registry.