### PR TITLE
Respect semver when resolving latest contracts in GH Actions workflows

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Resolve latest contracts
         run: |
-          yarn add \
+          yarn upgrade \
             @keep-network/keep-core@${{ steps.upstream-builds-query.outputs.keep-core-contracts-version }} \
             @keep-network/tbtc@${{ steps.upstream-builds-query.outputs.tbtc-contracts-version }}
 

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Resolve latest contracts
         run: |
-          yarn add \
+          yarn upgrade \
             @keep-network/keep-core \
             @keep-network/tbtc
 


### PR DESCRIPTION
In `Resolve latest contracts` step we were using `yarn add` command to
download the packages with the dependencies. But this command installs
the latest package (if exact package is not provided), ignoring the
semver config provided in the `package.json` file. Instead, we should
use `yarn upgrade`, which updates the dependencies to their latest
version based on the semver range specified in the `package.json`.
We can use the `yarn add` also if the command is followed by the package
name & version which does not fit the semver range - in that case semver
gets ignored and the indicated package gets installed.