### PR TITLE
Fix deployment of UniswapV2Router on `development` network

### DIFF
--- a/deploy/03_resolve_uniswap_v2_router.ts
+++ b/deploy/03_resolve_uniswap_v2_router.ts
@@ -12,7 +12,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     log(`using external UniswapV2Router at ${UniswapV2Router.address}`)
   } else if (
     !hre.network.tags.local ||
-    (('forking' in hre.network.config) && hre.network.config.forking.enabled)
+    ("forking" in hre.network.config && hre.network.config.forking.enabled)
   ) {
     throw new Error("deployed UniswapV2Router contract not found")
   } else {

--- a/deploy/03_resolve_uniswap_v2_router.ts
+++ b/deploy/03_resolve_uniswap_v2_router.ts
@@ -11,8 +11,8 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   if (UniswapV2Router && helpers.address.isValid(UniswapV2Router.address)) {
     log(`using external UniswapV2Router at ${UniswapV2Router.address}`)
   } else if (
-    hre.network.name !== "hardhat" ||
-    (hre.network.config as HardhatNetworkConfig).forking.enabled
+    !hre.network.tags.local ||
+    (('forking' in hre.network.config) && hre.network.config.forking.enabled)
   ) {
     throw new Error("deployed UniswapV2Router contract not found")
   } else {


### PR DESCRIPTION
Deployment of UniswapV2Router contract on `deployment` network was
failing with `deployed UniswapV2Router contract not found` error. This
was due to incorrect condition for throwing that error. After the fix
the error will be thrown if contract is missing and network is not
tagged as `local` (or if contract is missing and network has forking
enabled). In case of missing contract on `local`-tagged
network, stub contract will be deployed.