### PR TITLE
T cov pool: Do not allow the total value of collateral locked to exceed 2^96 - 1

### DIFF
--- a/contracts/AssetPool.sol
+++ b/contracts/AssetPool.sol
@@ -583,16 +583,6 @@ contract AssetPool is Ownable, IAssetPool {
         uint256 tokensToMint = (amountToDeposit * covSupply) /
             collateralBalance;
 
-        // The total supply of underwriter tokens cannot exceed `type(uint96).max`,
-        // because the maximum voting power in the underwriter token is
-        // `type(uint96).max`. Therefore the asset pool should not allow to mint
-        // more than `type(uint96).max` either. The amount of tokens to mint is
-        // stored in `uint256` just for gas efficiency.
-        require(
-            tokensToMint <= type(uint96).max,
-            "Minted tokens amount must be <= 2^96 - 1"
-        );
-
         return tokensToMint;
     }
 

--- a/contracts/AssetPool.sol
+++ b/contracts/AssetPool.sol
@@ -146,7 +146,8 @@ contract AssetPool is Ownable, IAssetPool {
 
     /// @notice Accepts the given amount of collateral token as a deposit and
     ///         mints underwriter tokens representing pool's ownership. The
-    ///         amount must be smaller or equal to 2^96-1.
+    ///         amount locked in the pool after accepting this deposit must
+    ///         be smaller or equal to 2^96-1; otherwise, the function reverts.
     ///         Optional data in extraData may include a minimal amount of
     ///         underwriter tokens expected to be minted for a depositor. There
     ///         are cases when an amount of minted tokens matters for a
@@ -159,8 +160,8 @@ contract AssetPool is Ownable, IAssetPool {
         bytes calldata extraData
     ) external {
         require(
-            amount <= type(uint96).max,
-            "deposited amount must be <= 2^96 - 1"
+            amount + totalValue() <= type(uint96).max,
+            "Pool capacity exceeded"
         );
         require(msg.sender == token, "Only token caller allowed");
         require(
@@ -182,7 +183,9 @@ contract AssetPool is Ownable, IAssetPool {
     }
 
     /// @notice Accepts the given amount of collateral token as a deposit and
-    ///         mints underwriter tokens representing pool's ownership.
+    ///         mints underwriter tokens representing pool's ownership. The
+    ///         amount locked in the pool after accepting this deposit must
+    ///         be smaller or equal to 2^96-1; otherwise, the function reverts.
     /// @dev Before calling this function, collateral token needs to have the
     ///      required amount accepted to transfer to the asset pool.
     /// @param amountToDeposit Collateral tokens amount that a user deposits to
@@ -195,8 +198,8 @@ contract AssetPool is Ownable, IAssetPool {
         returns (uint256)
     {
         require(
-            amountToDeposit <= type(uint96).max,
-            "deposited amount must be <= 2^96 - 1"
+            amountToDeposit + totalValue() <= type(uint96).max,
+            "Pool capacity exceeded"
         );
         uint256 toMint = _calculateTokensToMint(amountToDeposit);
         _deposit(msg.sender, amountToDeposit, toMint);
@@ -205,7 +208,9 @@ contract AssetPool is Ownable, IAssetPool {
 
     /// @notice Accepts the given amount of collateral token as a deposit and
     ///         mints at least a minAmountToMint underwriter tokens representing
-    ///         pool's ownership.
+    ///         pool's ownership. The amount locked in the pool after accepting
+    ///         this deposit must be smaller or equal to 2^96-1; otherwise, the
+    ///         function reverts.
     /// @dev Before calling this function, collateral token needs to have the
     ///      required amount accepted to transfer to the asset pool.
     /// @param amountToDeposit Collateral tokens amount that a user deposits to
@@ -221,8 +226,8 @@ contract AssetPool is Ownable, IAssetPool {
         returns (uint256)
     {
         require(
-            amountToDeposit <= type(uint96).max,
-            "deposited amount must be <= 2^96 - 1"
+            amountToDeposit + totalValue() <= type(uint96).max,
+            "Pool capacity exceeded"
         );
         uint256 toMint = _calculateTokensToMint(amountToDeposit);
 
@@ -547,7 +552,7 @@ contract AssetPool is Ownable, IAssetPool {
     ///         plus the reward amount (in collateral token) earned by the asset
     ///         pool and not yet withdrawn to the asset pool.
     /// @return The total value of asset pool in collateral token.
-    function totalValue() external view returns (uint256) {
+    function totalValue() public view returns (uint256) {
         return collateralToken.balanceOf(address(this)) + rewardsPool.earned();
     }
 

--- a/contracts/AssetPool.sol
+++ b/contracts/AssetPool.sol
@@ -580,10 +580,7 @@ contract AssetPool is Ownable, IAssetPool {
             return amountToDeposit;
         }
 
-        uint256 tokensToMint = (amountToDeposit * covSupply) /
-            collateralBalance;
-
-        return tokensToMint;
+        return (amountToDeposit * covSupply) / collateralBalance;
     }
 
     function _deposit(

--- a/contracts/UnderwriterToken.sol
+++ b/contracts/UnderwriterToken.sol
@@ -108,8 +108,6 @@ contract UnderwriterToken is ERC20WithPermit, Checkpoints {
         address to,
         uint256 amount
     ) internal override {
-        uint96 safeAmount = SafeCast.toUint96(amount);
-
         // When minting:
         if (from == address(0)) {
             // Does not allow to mint more than uint96 can fit. Otherwise, the
@@ -118,15 +116,15 @@ contract UnderwriterToken is ERC20WithPermit, Checkpoints {
                 totalSupply + amount <= maxSupply(),
                 "Maximum total supply exceeded"
             );
-            writeCheckpoint(_totalSupplyCheckpoints, add, safeAmount);
+            writeCheckpoint(_totalSupplyCheckpoints, add, amount);
         }
 
         // When burning:
         if (to == address(0)) {
-            writeCheckpoint(_totalSupplyCheckpoints, subtract, safeAmount);
+            writeCheckpoint(_totalSupplyCheckpoints, subtract, amount);
         }
 
-        moveVotingPower(delegates(from), delegates(to), safeAmount);
+        moveVotingPower(delegates(from), delegates(to), amount);
     }
 
     /// @notice Delegate votes from `delegator` to `delegatee`.

--- a/test/AssetPool.test.js
+++ b/test/AssetPool.test.js
@@ -366,7 +366,7 @@ describe("AssetPool", () => {
       it("should revert", async () => {
         await expect(
           assetPool.connect(underwriter2).deposit(3)
-        ).to.be.revertedWith("Minted tokens amount must be <= 2^96 - 1")
+        ).to.be.revertedWith("Maximum total supply exceeded")
       })
     })
   })

--- a/test/AssetPool.test.js
+++ b/test/AssetPool.test.js
@@ -179,7 +179,20 @@ describe("AssetPool", () => {
           .approve(assetPool.address, amount)
         await expect(
           assetPool.connect(underwriter1).deposit(amount)
-        ).to.be.revertedWith("deposited amount must be <= 2^96 - 1")
+        ).to.be.revertedWith("Pool capacity exceeded")
+      })
+    })
+
+    context("when pool is at its max capacity", async () => {
+      it("should revert", async () => {
+        const amount = 1
+        await collateralToken.mint(assetPool.address, MAX_UINT96)
+        await collateralToken
+          .connect(underwriter1)
+          .approve(assetPool.address, amount)
+        await expect(
+          assetPool.connect(underwriter1).deposit(amount)
+        ).to.be.revertedWith("Pool capacity exceeded")
       })
     })
 
@@ -368,7 +381,21 @@ describe("AssetPool", () => {
           .approve(assetPool.address, amount)
         await expect(
           assetPool.connect(underwriter1).depositWithMin(amount, minCovToMint)
-        ).to.be.revertedWith("deposited amount must be <= 2^96 - 1")
+        ).to.be.revertedWith("Pool capacity exceeded")
+      })
+    })
+
+    context("when pool is at its max capacity", () => {
+      it("should revert", async () => {
+        const amount = 1
+        const minCovToMint = amount
+        await collateralToken.mint(assetPool.address, MAX_UINT96)
+        await collateralToken
+          .connect(underwriter1)
+          .approve(assetPool.address, amount)
+        await expect(
+          assetPool.connect(underwriter1).depositWithMin(amount, minCovToMint)
+        ).to.be.revertedWith("Pool capacity exceeded")
       })
     })
 
@@ -495,7 +522,20 @@ describe("AssetPool", () => {
             collateralToken
               .connect(underwriter1)
               .approveAndCall(assetPool.address, amount, data)
-          ).to.be.revertedWith("deposited amount must be <= 2^96 - 1")
+          ).to.be.revertedWith("Pool capacity exceeded")
+        })
+      })
+
+      context("when pool is at its max capacity", () => {
+        it("should revert", async () => {
+          const amount = 1
+          await collateralToken.mint(assetPool.address, MAX_UINT96)
+          const data = abiCoder.encode(["uint256"], [amount])
+          await expect(
+            collateralToken
+              .connect(underwriter1)
+              .approveAndCall(assetPool.address, amount, data)
+          ).to.be.revertedWith("Pool capacity exceeded")
         })
       })
 


### PR DESCRIPTION
In the previous PRs (see #199) we limited the amount of collateral locked to `2^96 - 1` and added support for governance checkpoints to `UnderwriterToken` contract.

Unfortunately, the validation in deposit function was not entirely correct. Instead of validating that a single deposit can not exceed `2^96 - 1`, we should expect that the total value locked in the pool, including all previous deposits plus the amount that is about to be deposited, does not exceed `2^96 - 1`. This way we better guard that no more than `2^96 - 1` underwriter token is minted. 

With the previous version, it was possible to perform multiple deposits and bypass the validation check. This would still fail later on `UnderWriterToken`'s `beforeTokenTransfer` check but the validation checks in deposit functions were not entirely correct and intuitive.