### PR TITLE
Unify CI workflows

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -215,7 +215,7 @@ jobs:
 
       - name: Install Solidity
         env:
-          SOLC_VERSION: 0.8.5 # according to solidity.version in hardhat.config.ts
+          SOLC_VERSION: 0.8.5 # according to solidity.version in hardhat.config.js
         run: |
           pip3 install solc-select
           solc-select install $SOLC_VERSION

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -70,11 +70,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Load environment variables
-        uses: keep-network/ci/actions/load-env-variables@v1
-        with:
-          environment: ${{ github.event.inputs.environment }}
-
       - uses: actions/setup-node@v2
         with:
           node-version: "14.x"

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -79,6 +79,7 @@ jobs:
         with:
           node-version: "14.x"
           cache: "yarn"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
@@ -119,9 +120,9 @@ jobs:
           commit: ${{ github.sha }}
 
       - name: Publish to npm
-        run: |
-          echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }} > .npmrc
-          npm publish --access=public --network=${{ github.event.inputs.environment }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access=public --network=${{ github.event.inputs.environment }}
 
       - name: Notify CI about completion of the workflow
         uses: keep-network/ci/actions/notify-workflow-completed@v1

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -44,4 +44,4 @@ jobs:
       - name: Publish package
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access=public --network=hardhat --tag=development
+        run: npm publish --access=public --network=hardhat --tag=dev


### PR DESCRIPTION
We have CI workflows scattered across various repositories. We try to keep their implementation as similar as possible. In this PR and the ones listed below we introduce a couple of changes which unify used solutions and fix small mistakes, such as:
* making tagging of published packages consistent
* passing `NPM_TOKEN` secret as variable instead of passing it by writing to file
* handling caching of npm/yarn dependencies via `setup-node` action
* adding `workflow_dispatch` job trigger where it's missing
* using Node.js in version 14.x instead of 12.x where possible

Related PRs in other repositories:
* https://github.com/keep-network/keep-core/pull/2776
* https://github.com/keep-network/keep-ecdsa/pull/941
* https://github.com/keep-network/tbtc/pull/842
* https://github.com/keep-network/tbtc.js/pull/145
* https://github.com/keep-network/sortition-pools/pull/145
* https://github.com/keep-network/local-setup/pull/124
* https://github.com/keep-network/tbtc-v2/pull/88
* https://github.com/threshold-network/solidity-contracts/pull/59