### PR TITLE
DAO support for Coverage Pool underwriters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ yarn-error.log
 
 .hardhat/*
 !.hardhat/networks_TEMPLATE.ts
+hardhat-dependency-compiler/

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,4 @@ cache/
 deployments/
 typechain/
 export.json
+hardhat-dependency-compiler/

--- a/.solhintignore
+++ b/.solhintignore
@@ -1,2 +1,2 @@
-
 node_modules/
+hardhat-dependency-compiler/

--- a/contracts/AssetPool.sol
+++ b/contracts/AssetPool.sol
@@ -143,6 +143,15 @@ contract AssetPool is Ownable, IAssetPool {
             rewardsManager
         );
 
+        initGovernance(_collateralToken);
+    }
+
+    /// @dev Overwrite to empty if collateral token used by the AssetPool
+    ///      does not support DAO checkpoints. Used for tests with KEEP token.
+    function initGovernance(ICollateralToken _collateralToken)
+        internal
+        virtual
+    {
         _collateralToken.delegate(address(this));
     }
 

--- a/contracts/AssetPool.sol
+++ b/contracts/AssetPool.sol
@@ -16,11 +16,11 @@ pragma solidity 0.8.5;
 
 import "./interfaces/IAssetPool.sol";
 import "./interfaces/IAssetPoolUpgrade.sol";
+import "./interfaces/ICollateralToken.sol";
 import "./RewardsPool.sol";
 import "./UnderwriterToken.sol";
 import "./GovernanceUtils.sol";
 
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
@@ -35,10 +35,10 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 ///         can not be greater than 2^96-1 or, if that supply is greater, it is
 ///         acceptable that not all tokens can be deposited into the pool.
 contract AssetPool is Ownable, IAssetPool {
-    using SafeERC20 for IERC20;
+    using SafeERC20 for ICollateralToken;
     using SafeERC20 for UnderwriterToken;
 
-    IERC20 public immutable collateralToken;
+    ICollateralToken public immutable collateralToken;
     UnderwriterToken public immutable underwriterToken;
 
     RewardsPool public immutable rewardsPool;
@@ -130,7 +130,7 @@ contract AssetPool is Ownable, IAssetPool {
     }
 
     constructor(
-        IERC20 _collateralToken,
+        ICollateralToken _collateralToken,
         UnderwriterToken _underwriterToken,
         address rewardsManager
     ) {

--- a/contracts/AssetPool.sol
+++ b/contracts/AssetPool.sol
@@ -12,7 +12,7 @@
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.5;
+pragma solidity 0.8.9;
 
 import "./interfaces/IAssetPool.sol";
 import "./interfaces/IAssetPoolUpgrade.sol";

--- a/contracts/AssetPool.sol
+++ b/contracts/AssetPool.sol
@@ -142,6 +142,8 @@ contract AssetPool is Ownable, IAssetPool {
             address(this),
             rewardsManager
         );
+
+        _collateralToken.delegate(address(this));
     }
 
     /// @notice Accepts the given amount of collateral token as a deposit and

--- a/contracts/Auction.sol
+++ b/contracts/Auction.sol
@@ -12,7 +12,7 @@
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.5;
+pragma solidity 0.8.9;
 
 import "./interfaces/IAuction.sol";
 import "./Auctioneer.sol";

--- a/contracts/AuctionBidder.sol
+++ b/contracts/AuctionBidder.sol
@@ -12,7 +12,7 @@
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.5;
+pragma solidity 0.8.9;
 
 import "./Auction.sol";
 import "./CoveragePool.sol";

--- a/contracts/Auctioneer.sol
+++ b/contracts/Auctioneer.sol
@@ -12,7 +12,7 @@
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.5;
+pragma solidity 0.8.9;
 
 import "./Auction.sol";
 import "./CoveragePool.sol";

--- a/contracts/CoveragePool.sol
+++ b/contracts/CoveragePool.sol
@@ -15,12 +15,12 @@
 pragma solidity 0.8.5;
 
 import "./interfaces/IAssetPoolUpgrade.sol";
+import "./interfaces/ICollateralToken.sol";
 import "./AssetPool.sol";
 import "./CoveragePoolConstants.sol";
 import "./GovernanceUtils.sol";
 
 import "@openzeppelin/contracts/access/Ownable.sol";
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 /// @title Coverage Pool
 /// @notice A contract that manages a single asset pool. Handles approving and
@@ -30,7 +30,7 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 ///      owner of the asset pool contract.
 contract CoveragePool is Ownable {
     AssetPool public immutable assetPool;
-    IERC20 public immutable collateralToken;
+    ICollateralToken public immutable collateralToken;
 
     bool public firstRiskManagerApproved = false;
 

--- a/contracts/CoveragePool.sol
+++ b/contracts/CoveragePool.sol
@@ -268,11 +268,11 @@ contract CoveragePool is Ownable {
             account,
             blockNumber
         );
-        uint96 underwriterSupply = underwriterToken.getPastTotalSupply(
+        uint96 underwriterTokenSupply = underwriterToken.getPastTotalSupply(
             blockNumber
         );
 
-        if (underwriterSupply == 0) {
+        if (underwriterTokenSupply == 0) {
             return 0;
         }
 
@@ -283,7 +283,8 @@ contract CoveragePool is Ownable {
 
         return
             uint96(
-                (uint256(underwriterVotes) * covPoolVotes) / underwriterSupply
+                (uint256(underwriterVotes) * covPoolVotes) /
+                    underwriterTokenSupply
             );
     }
 

--- a/contracts/CoveragePool.sol
+++ b/contracts/CoveragePool.sol
@@ -12,7 +12,7 @@
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.5;
+pragma solidity 0.8.9;
 
 import "./interfaces/IAssetPoolUpgrade.sol";
 import "./interfaces/ICollateralToken.sol";

--- a/contracts/CoveragePoolBeneficiary.sol
+++ b/contracts/CoveragePoolBeneficiary.sol
@@ -12,7 +12,7 @@
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.5;
+pragma solidity 0.8.9;
 
 import "./RewardsPool.sol";
 

--- a/contracts/CoveragePoolConstants.sol
+++ b/contracts/CoveragePoolConstants.sol
@@ -12,7 +12,7 @@
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.5;
+pragma solidity 0.8.9;
 
 library CoveragePoolConstants {
     // This divisor is for precision purposes only. We use this divisor around

--- a/contracts/GovernanceUtils.sol
+++ b/contracts/GovernanceUtils.sol
@@ -12,7 +12,7 @@
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.5;
+pragma solidity 0.8.9;
 
 library GovernanceUtils {
     /// @notice Gets the time remaining until the governable parameter update

--- a/contracts/RewardsPool.sol
+++ b/contracts/RewardsPool.sol
@@ -12,7 +12,7 @@
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.5;
+pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";

--- a/contracts/RiskManagerV1.sol
+++ b/contracts/RiskManagerV1.sol
@@ -12,7 +12,7 @@
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.5;
+pragma solidity 0.8.9;
 
 import "./interfaces/IRiskManagerV1.sol";
 import "./Auctioneer.sol";

--- a/contracts/SignerBondsManualSwap.sol
+++ b/contracts/SignerBondsManualSwap.sol
@@ -12,7 +12,7 @@
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.5;
+pragma solidity 0.8.9;
 
 import "./interfaces/IRiskManagerV1.sol";
 import "./RiskManagerV1.sol";

--- a/contracts/SignerBondsUniswapV2.sol
+++ b/contracts/SignerBondsUniswapV2.sol
@@ -12,7 +12,7 @@
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.5;
+pragma solidity 0.8.9;
 
 import "./interfaces/IRiskManagerV1.sol";
 import "./RiskManagerV1.sol";

--- a/contracts/UnderwriterToken.sol
+++ b/contracts/UnderwriterToken.sol
@@ -28,6 +28,7 @@ import "@threshold-network/solidity-contracts/contracts/governance/Checkpoints.s
 ///         Anyone can submit this signature on the user's behalf by calling the
 ///         permit function, as specified in EIP2612 standard, paying gas fees,
 ///         and possibly performing other actions in the same transaction.
+// slither-disable-next-line missing-inheritance
 contract UnderwriterToken is ERC20WithPermit, Checkpoints {
     /// @notice The EIP-712 typehash for the delegation struct used by
     ///         `delegateBySig`.

--- a/contracts/UnderwriterToken.sol
+++ b/contracts/UnderwriterToken.sol
@@ -14,6 +14,7 @@
 
 pragma solidity 0.8.9;
 
+import "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import "@thesis/solidity-contracts/contracts/token/ERC20WithPermit.sol";
 import "@threshold-network/solidity-contracts/contracts/governance/Checkpoints.sol";
 

--- a/contracts/UnderwriterToken.sol
+++ b/contracts/UnderwriterToken.sol
@@ -12,7 +12,7 @@
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.5;
+pragma solidity 0.8.9;
 
 import "@thesis/solidity-contracts/contracts/token/ERC20WithPermit.sol";
 import "@threshold-network/solidity-contracts/contracts/governance/Checkpoints.sol";

--- a/contracts/interfaces/IAssetPool.sol
+++ b/contracts/interfaces/IAssetPool.sol
@@ -12,7 +12,7 @@
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.5;
+pragma solidity 0.8.9;
 
 /// @title Asset Pool interface
 /// @notice Asset Pool accepts a single ERC20 token as collateral, and returns

--- a/contracts/interfaces/IAssetPoolUpgrade.sol
+++ b/contracts/interfaces/IAssetPoolUpgrade.sol
@@ -12,7 +12,7 @@
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.5;
+pragma solidity 0.8.9;
 
 /// @title Asset Pool upgrade interface
 /// @notice Interface that has to be implemented by an Asset Pool accepting

--- a/contracts/interfaces/IAuction.sol
+++ b/contracts/interfaces/IAuction.sol
@@ -12,7 +12,7 @@
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.5;
+pragma solidity 0.8.9;
 
 /// @title Auction interface
 /// @notice Auction runs a linear falling-price auction against a diverse

--- a/contracts/interfaces/ICollateralToken.sol
+++ b/contracts/interfaces/ICollateralToken.sol
@@ -25,10 +25,12 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 ///         Coverage Pool underwriters can participate in token holder DAO.
 /// @dev See @threshold-network/solidity-contracts/contracts/governance/Checkpoints.sol
 interface ICollateralToken is IERC20 {
-    /// @notice Determine the prior number of votes for an account as of
+    /// @notice Delegate DAO votes from `msg.sender` to `delegatee`.
+    /// @param delegatee The address to delegate votes to
+    function delegate(address delegatee) external;
+
+    /// @notice Determine the prior number of DAO votes for an account as of
     ///         a block number.
-    /// @dev Block number must be a finalized block or else this function will
-    ///      revert to prevent misinformation.
     /// @param account The address of the account to check
     /// @param blockNumber The block number to get the vote balance at
     /// @return The number of votes the account had as of the given block

--- a/contracts/interfaces/ICollateralToken.sol
+++ b/contracts/interfaces/ICollateralToken.sol
@@ -1,0 +1,39 @@
+// ▓▓▌ ▓▓ ▐▓▓ ▓▓▓▓▓▓▓▓▓▓▌▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▄
+// ▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▌▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
+//   ▓▓▓▓▓▓    ▓▓▓▓▓▓▓▀    ▐▓▓▓▓▓▓    ▐▓▓▓▓▓   ▓▓▓▓▓▓     ▓▓▓▓▓   ▐▓▓▓▓▓▌   ▐▓▓▓▓▓▓
+//   ▓▓▓▓▓▓▄▄▓▓▓▓▓▓▓▀      ▐▓▓▓▓▓▓▄▄▄▄         ▓▓▓▓▓▓▄▄▄▄         ▐▓▓▓▓▓▌   ▐▓▓▓▓▓▓
+//   ▓▓▓▓▓▓▓▓▓▓▓▓▓▀        ▐▓▓▓▓▓▓▓▓▓▓         ▓▓▓▓▓▓▓▓▓▓         ▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
+//   ▓▓▓▓▓▓▀▀▓▓▓▓▓▓▄       ▐▓▓▓▓▓▓▀▀▀▀         ▓▓▓▓▓▓▀▀▀▀         ▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▀
+//   ▓▓▓▓▓▓   ▀▓▓▓▓▓▓▄     ▐▓▓▓▓▓▓     ▓▓▓▓▓   ▓▓▓▓▓▓     ▓▓▓▓▓   ▐▓▓▓▓▓▌
+// ▓▓▓▓▓▓▓▓▓▓ █▓▓▓▓▓▓▓▓▓ ▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓  ▓▓▓▓▓▓▓▓▓▓
+// ▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓ ▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓  ▓▓▓▓▓▓▓▓▓▓
+//
+//                           Trust math, not hardware.
+
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.5;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+/// @title Collateral Token interface
+/// @notice ERC-20 token which is accepted by the pool as collateral and used
+///         as a deposit token by underwriters. Collateral token positions of
+///         underwriters can be affected when the Risk Manager claims coverage.
+///         Collateral token needs to support DAO checkpoints and let to
+///         retrieve past number of votes for the given address so that
+///         Coverage Pool underwriters can participate in token holder DAO.
+/// @dev See @threshold-network/solidity-contracts/contracts/governance/Checkpoints.sol
+interface ICollateralToken is IERC20 {
+    /// @notice Determine the prior number of votes for an account as of
+    ///         a block number.
+    /// @dev Block number must be a finalized block or else this function will
+    ///      revert to prevent misinformation.
+    /// @param account The address of the account to check
+    /// @param blockNumber The block number to get the vote balance at
+    /// @return The number of votes the account had as of the given block
+    function getPastVotes(address account, uint256 blockNumber)
+        external
+        view
+        returns (uint96);
+}

--- a/contracts/interfaces/ICollateralToken.sol
+++ b/contracts/interfaces/ICollateralToken.sol
@@ -12,7 +12,7 @@
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.5;
+pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/contracts/interfaces/IRiskManagerV1.sol
+++ b/contracts/interfaces/IRiskManagerV1.sol
@@ -12,7 +12,7 @@
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.5;
+pragma solidity 0.8.9;
 
 /// @title Interface for tBTC v1 Risk Manager
 /// @notice Risk Manager is a smart contract with the exclusive right to claim

--- a/contracts/test/AuctionStub.sol
+++ b/contracts/test/AuctionStub.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.5;
+pragma solidity 0.8.9;
 
 import "../interfaces/IAuction.sol";
 

--- a/contracts/test/AuctioneerStub.sol
+++ b/contracts/test/AuctioneerStub.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.5;
+pragma solidity 0.8.9;
 
 import "../Auctioneer.sol";
 

--- a/contracts/test/CoveragePoolStub.sol
+++ b/contracts/test/CoveragePoolStub.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.5;
+pragma solidity 0.8.9;
 
 import "../CoveragePoolConstants.sol";
 

--- a/contracts/test/DepositStub.sol
+++ b/contracts/test/DepositStub.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.5;
+pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 

--- a/contracts/test/KeepAssetPool.sol
+++ b/contracts/test/KeepAssetPool.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.9;
+
+import "../AssetPool.sol";
+
+contract KeepAssetPool is AssetPool {
+    constructor(
+        ICollateralToken collateralToken,
+        UnderwriterToken underwriterToken,
+        address rewardsManager
+    ) AssetPool(collateralToken, underwriterToken, rewardsManager) {}
+
+    function initGovernance(ICollateralToken _collateralToken)
+        internal
+        override
+    {
+        // KEEP does not support DAO checkpoints
+    }
+}

--- a/contracts/test/NewAssetPoolStub.sol
+++ b/contracts/test/NewAssetPoolStub.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.5;
+pragma solidity 0.8.9;
 
 import "../interfaces/IAssetPool.sol";
 import "../interfaces/IAssetPoolUpgrade.sol";

--- a/contracts/test/RiskManagerV1Stub.sol
+++ b/contracts/test/RiskManagerV1Stub.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.5;
+pragma solidity 0.8.9;
 
 import "../RiskManagerV1.sol";
 

--- a/contracts/test/SignerBondsUniswapV2Stub.sol
+++ b/contracts/test/SignerBondsUniswapV2Stub.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.5;
+pragma solidity 0.8.9;
 
 import "../SignerBondsUniswapV2.sol";
 

--- a/contracts/test/TBTCDepositTokenStub.sol
+++ b/contracts/test/TBTCDepositTokenStub.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.5;
+pragma solidity 0.8.9;
 
 import "../RiskManagerV1.sol";
 

--- a/contracts/test/TestToken.sol
+++ b/contracts/test/TestToken.sol
@@ -2,9 +2,30 @@
 
 pragma solidity 0.8.9;
 
+import "../interfaces/ICollateralToken.sol";
+
 import "@thesis/solidity-contracts/contracts/token/ERC20WithPermit.sol";
 
-contract TestToken is ERC20WithPermit {
+/// @title Test ERC-20 token
+/// @dev Token with unlimited minting capacity. It does implement DAO-related
+///      functions from ICollateralToken but with just a dummy code.
+///      Implementation of DAO checkpoints is complex. Even if we used
+///      `Checkpoints` contract from `threshold-network` here, it would require
+///      implementation for `delegate(address delegator, address delegatee)` and
+///      updating checkpoints in `beforeTokenTransfer(address from, address to, uint amount)`
+///      of TestToken. Every time DAO related functions need to be tested, please
+///      use real token with proper DAO implementation, such as `T`.
+contract TestToken is ERC20WithPermit, ICollateralToken {
+    mapping(address => address) public delegatee;
+
     /* solhint-disable-next-line no-empty-blocks */
     constructor() ERC20WithPermit("Test Token", "TT") {}
+
+    function delegate(address _delegatee) external virtual {
+        delegatee[msg.sender] = _delegatee;
+    }
+
+    function getPastVotes(address, uint256) external pure returns (uint96) {
+        return 0;
+    }
 }

--- a/contracts/test/TestToken.sol
+++ b/contracts/test/TestToken.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.5;
+pragma solidity 0.8.9;
 
 import "@thesis/solidity-contracts/contracts/token/ERC20WithPermit.sol";
 

--- a/contracts/test/UniswapV2RouterStub.sol
+++ b/contracts/test/UniswapV2RouterStub.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.5;
+pragma solidity 0.8.9;
 
 import "../SignerBondsUniswapV2.sol";
 

--- a/contracts/v2/RewardsPoolV2.sol
+++ b/contracts/v2/RewardsPoolV2.sol
@@ -12,7 +12,7 @@
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.5;
+pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -13,7 +13,7 @@ const config: HardhatUserConfig = {
   solidity: {
     compilers: [
       {
-        version: "0.8.5",
+        version: "0.8.9",
       },
     ],
   },

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -6,6 +6,7 @@ import "@nomiclabs/hardhat-waffle"
 import "@nomiclabs/hardhat-ethers"
 import "hardhat-gas-reporter"
 import "hardhat-deploy"
+import "hardhat-dependency-compiler"
 import "solidity-coverage"
 import "@tenderly/hardhat-tenderly"
 
@@ -19,6 +20,10 @@ const config: HardhatUserConfig = {
   },
   paths: {
     artifacts: "./build",
+  },
+  dependencyCompiler: {
+    paths: ["@threshold-network/solidity-contracts/contracts/token/T.sol"],
+    keep: true,
   },
   networks: {
     hardhat: {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@keep-network/keep-core": ">1.8.0-dev <1.8.0-pre",
     "@keep-network/tbtc": ">1.1.2-dev <1.1.2-ropsten",
     "@thesis/solidity-contracts": "github:thesis/solidity-contracts#4985bcf",
-    "@threshold-network/solidity-contracts": "1.0.0",
+    "@threshold-network/solidity-contracts": "github:threshold-network/solidity-contracts#0f07c2f",
     "@openzeppelin/contracts": "^4.3",
     "@tenderly/hardhat-tenderly": "^1.0.12"
   },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@keep-network/keep-core": ">1.8.0-dev <1.8.0-pre",
     "@keep-network/tbtc": ">1.1.2-dev <1.1.2-ropsten",
     "@thesis/solidity-contracts": "github:thesis/solidity-contracts#4985bcf",
-    "@threshold-network/solidity-contracts": "github:threshold-network/solidity-contracts#6664c73",
+    "@threshold-network/solidity-contracts": "1.0.0",
     "@openzeppelin/contracts": "^4.3",
     "@tenderly/hardhat-tenderly": "^1.0.12"
   },

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "ethereum-waffle": "^3.4.0",
     "ethers": "^5.0.32",
     "hardhat": "^2.6.4",
+    "hardhat-dependency-compiler": "^1.1.1",
     "hardhat-deploy": "^0.9.1",
     "hardhat-gas-reporter": "^1.0.4",
     "prettier": "^2.3.2",

--- a/test/AssetPool.test.js
+++ b/test/AssetPool.test.js
@@ -84,6 +84,14 @@ describe("AssetPool", () => {
     underwriter4 = await createUnderwriterWithTokens(7)
   })
 
+  describe("constructor", () => {
+    it("should self-delegate voting power", async () => {
+      expect(await collateralToken.delegatee(assetPool.address)).to.equal(
+        assetPool.address
+      )
+    })
+  })
+
   describe("deposit", () => {
     context("when the depositor has not enough collateral tokens", () => {
       it("should revert", async () => {

--- a/test/CoveragePool.test.js
+++ b/test/CoveragePool.test.js
@@ -4,40 +4,52 @@ const {
   to1ePrecision,
   increaseTime,
   lastBlockTime,
+  lastBlockNumber,
+  mineBlock,
 } = require("./helpers/contract-test-helpers")
 
 describe("CoveragePool", () => {
   let coveragePool
   let assetPool
-  let testToken
+  let collateralToken
   let underwriterToken
 
   let governance
-  let underwriter
+  let underwriter1
+  let underwriter2
   let recipient
   let riskManager
   let anotherRiskManager
+  let rewardsManager
   let thirdParty
+
+  // expected withdrawal delay in seconds
+  const withdrawalDelay = 21 * 24 * 3600
+  // expected reward interval in seconds
+  const rewardInterval = 7 * 24 * 3600
 
   beforeEach(async () => {
     // Governance that owns Coverage Pool
     governance = await ethers.getSigner(1)
     // Underwriter that will deposit some amount of tokens to Asset Pool
-    underwriter = await ethers.getSigner(2)
+    underwriter1 = await ethers.getSigner(2)
+    underwriter2 = await ethers.getSigner(3)
     // Recipient that will receive seized funds
-    recipient = await ethers.getSigner(3)
+    recipient = await ethers.getSigner(4)
     // The main risk manager
-    riskManager = await ethers.getSigner(4)
+    riskManager = await ethers.getSigner(5)
     // Another risk manager
-    anotherRiskManager = await ethers.getSigner(5)
+    anotherRiskManager = await ethers.getSigner(6)
     // Account that is not authorized to call functions on Coverage Pool
-    thirdParty = await ethers.getSigner(6)
+    thirdParty = await ethers.getSigner(7)
     // Account funding Asset Pool with rewards
-    const rewardsManager = await ethers.getSigner(7)
+    rewardsManager = await ethers.getSigner(8)
 
-    const TestToken = await ethers.getContractFactory("TestToken")
-    testToken = await TestToken.deploy()
-    await testToken.deployed()
+    // To test `getPastVotes` we need a token properly implementing DAO
+    // checkpoints. Using T instead of reinventing the wheel in TestToken.
+    const T = await ethers.getContractFactory("T")
+    collateralToken = await T.deploy()
+    await collateralToken.deployed()
 
     const UnderwriterToken = await ethers.getContractFactory("UnderwriterToken")
     underwriterToken = await UnderwriterToken.deploy("Underwriter Token", "COV")
@@ -45,7 +57,7 @@ describe("CoveragePool", () => {
 
     const AssetPool = await ethers.getContractFactory("AssetPool")
     assetPool = await AssetPool.deploy(
-      testToken.address,
+      collateralToken.address,
       underwriterToken.address,
       rewardsManager.address
     )
@@ -58,11 +70,6 @@ describe("CoveragePool", () => {
     await coveragePool.transferOwnership(governance.address)
     await assetPool.transferOwnership(coveragePool.address)
     await underwriterToken.transferOwnership(assetPool.address)
-
-    // Deposit 400 tokens to the asset pool
-    await testToken.mint(underwriter.address, to1e18(400))
-    await testToken.connect(underwriter).approve(assetPool.address, to1e18(400))
-    await assetPool.connect(underwriter).deposit(to1e18(400))
   })
 
   describe("approveFirstRiskManager", () => {
@@ -348,6 +355,15 @@ describe("CoveragePool", () => {
   })
 
   describe("seizeFunds", () => {
+    beforeEach(async () => {
+      // Deposit 400 tokens to the asset pool
+      await collateralToken.mint(underwriter1.address, to1e18(400))
+      await collateralToken
+        .connect(underwriter1)
+        .approve(assetPool.address, to1e18(400))
+      await assetPool.connect(underwriter1).deposit(to1e18(400))
+    })
+
     context("when caller is not an approved Risk Manager", () => {
       it("should revert", async () => {
         await expect(
@@ -372,7 +388,7 @@ describe("CoveragePool", () => {
         await coveragePool
           .connect(riskManager)
           .seizeFunds(recipient.address, portionToSeize)
-        expect(await testToken.balanceOf(recipient.address)).to.be.equal(
+        expect(await collateralToken.balanceOf(recipient.address)).to.be.equal(
           amountSeized
         )
       })
@@ -428,6 +444,321 @@ describe("CoveragePool", () => {
         expect(
           await underwriterToken.balanceOf(thirdParty.address)
         ).to.be.equal(to1e18(10))
+      })
+    })
+  })
+
+  describe("getPastVotes", async () => {
+    let lastFinalizedBlock
+
+    beforeEach(async () => {
+      await underwriterToken
+        .connect(underwriter1)
+        .delegate(underwriter1.address)
+      await underwriterToken
+        .connect(underwriter2)
+        .delegate(underwriter2.address)
+    })
+
+    context("when no tokens were deposited into the pool", () => {
+      beforeEach(async () => {
+        lastFinalizedBlock = (await lastBlockNumber()) - 1
+      })
+
+      it("should return zero", async () => {
+        expect(
+          await coveragePool.getPastVotes(
+            underwriter1.address,
+            lastFinalizedBlock
+          )
+        ).to.equal(0)
+      })
+    })
+
+    context("when underwriter did not delegate voting", () => {
+      beforeEach(async () => {
+        // Underwriter deposits into the asset pool
+        await collateralToken.mint(underwriter1.address, to1e18(400))
+        await collateralToken
+          .connect(underwriter1)
+          .approve(assetPool.address, to1e18(400))
+        await assetPool.connect(underwriter1).deposit(to1e18(400))
+
+        lastFinalizedBlock = (await lastBlockNumber()) - 1
+      })
+
+      it("should return zero", async () => {
+        expect(
+          await collateralToken.getPastVotes(
+            underwriter1.address,
+            lastFinalizedBlock
+          )
+        ).to.equal(0)
+      })
+    })
+
+    context("when account did not deposit into the pool", () => {
+      beforeEach(async () => {
+        // Some other underwriter deposits into the asset pool
+        await collateralToken.mint(underwriter1.address, to1e18(400))
+        await collateralToken
+          .connect(underwriter1)
+          .approve(assetPool.address, to1e18(400))
+        await assetPool.connect(underwriter1).deposit(to1e18(400))
+
+        lastFinalizedBlock = (await lastBlockNumber()) - 1
+      })
+
+      it("should return zero", async () => {
+        expect(
+          await coveragePool.getPastVotes(
+            thirdParty.address,
+            lastFinalizedBlock
+          )
+        ).to.equal(0)
+      })
+    })
+
+    context("when single underwriter deposited into the pool", () => {
+      const depositedAmount = to1e18(401)
+
+      beforeEach(async () => {
+        // Mint to some unrelated account
+        await collateralToken.mint(thirdParty.address, to1e18(100000))
+
+        // Underwriter deposits into the asset pool
+        await collateralToken.mint(underwriter1.address, depositedAmount)
+        await collateralToken
+          .connect(underwriter1)
+          .approve(assetPool.address, depositedAmount)
+        await assetPool.connect(underwriter1).deposit(depositedAmount)
+
+        await mineBlock()
+        lastFinalizedBlock = (await lastBlockNumber()) - 1
+      })
+
+      it("should return correct voting power", async () => {
+        expect(
+          await coveragePool.getPastVotes(
+            underwriter1.address,
+            lastFinalizedBlock
+          )
+        ).to.equal(depositedAmount)
+      })
+    })
+
+    context("when multiple underwriters deposited into the pool", () => {
+      const depositedAmount1 = to1e18(400)
+      const depositedAmount2 = to1e18(200)
+
+      beforeEach(async () => {
+        // Mint to some unrelated account
+        await collateralToken.mint(thirdParty.address, to1e18(100000))
+
+        // First underwriter deposits into the asset pool
+        await collateralToken.mint(underwriter1.address, depositedAmount1)
+        await collateralToken
+          .connect(underwriter1)
+          .approve(assetPool.address, depositedAmount1)
+        await assetPool.connect(underwriter1).deposit(depositedAmount1)
+
+        // Second underwriter deposits into the asset pool
+        await collateralToken.mint(underwriter2.address, depositedAmount2)
+        await collateralToken
+          .connect(underwriter2)
+          .approve(assetPool.address, depositedAmount2)
+        await assetPool.connect(underwriter2).deposit(depositedAmount2)
+
+        await mineBlock()
+        lastFinalizedBlock = (await lastBlockNumber()) - 1
+      })
+
+      context("when no one withdrawn, there were no claims or rewards", () => {
+        it("should return correct voting power", async () => {
+          expect(
+            await coveragePool.getPastVotes(
+              underwriter1.address,
+              lastFinalizedBlock
+            )
+          ).to.equal(depositedAmount1)
+
+          expect(
+            await coveragePool.getPastVotes(
+              underwriter2.address,
+              lastFinalizedBlock
+            )
+          ).to.equal(depositedAmount2)
+        })
+      })
+
+      context("when one underwriter partially withdrawn", async () => {
+        // no liquidations so COV amount = withdrawn amount
+        // 400 - 100 = 300
+        const withdrawnAmount = to1e18(100)
+
+        beforeEach(async () => {
+          await underwriterToken
+            .connect(underwriter1)
+            .approve(assetPool.address, withdrawnAmount)
+          await assetPool
+            .connect(underwriter1)
+            .initiateWithdrawal(withdrawnAmount)
+          await increaseTime(withdrawalDelay)
+          await assetPool
+            .connect(underwriter1)
+            .completeWithdrawal(underwriter1.address)
+
+          await mineBlock()
+          lastFinalizedBlock = (await lastBlockNumber()) - 1
+        })
+
+        it("should return correct voting power", async () => {
+          expect(
+            await coveragePool.getPastVotes(
+              underwriter1.address,
+              lastFinalizedBlock
+            )
+          ).to.equal(depositedAmount1.sub(withdrawnAmount))
+
+          expect(
+            await coveragePool.getPastVotes(
+              underwriter2.address,
+              lastFinalizedBlock
+            )
+          ).to.equal(depositedAmount2)
+        })
+      })
+
+      context("when one underwriter completely withdrawn", async () => {
+        // no liquidations so COV amount = withdrawn amount
+        const withdrawnAmount = depositedAmount1
+
+        beforeEach(async () => {
+          await underwriterToken
+            .connect(underwriter1)
+            .approve(assetPool.address, withdrawnAmount)
+          await assetPool
+            .connect(underwriter1)
+            .initiateWithdrawal(withdrawnAmount)
+          await increaseTime(withdrawalDelay)
+          await assetPool
+            .connect(underwriter1)
+            .completeWithdrawal(underwriter1.address)
+
+          await mineBlock()
+          lastFinalizedBlock = (await lastBlockNumber()) - 1
+        })
+
+        it("should return correct voting power", async () => {
+          expect(
+            await coveragePool.getPastVotes(
+              underwriter1.address,
+              lastFinalizedBlock
+            )
+          ).to.equal(0)
+
+          expect(
+            await coveragePool.getPastVotes(
+              underwriter2.address,
+              lastFinalizedBlock
+            )
+          ).to.equal(depositedAmount2)
+        })
+      })
+
+      context("when rewards were allocated", async () => {
+        const assertionPrecision = ethers.BigNumber.from("10000000") // 0.00000000001
+        const allocatedReward = to1e18(90)
+
+        beforeEach(async () => {
+          const rewardsPoolAddress = await assetPool.rewardsPool()
+          const rewardsPool = await ethers.getContractAt(
+            "RewardsPool",
+            rewardsPoolAddress,
+            rewardsManager
+          )
+
+          // Allocate reward and wait for the entire length of the reward
+          // interval.
+          await collateralToken.mint(rewardsManager.address, allocatedReward)
+          await collateralToken
+            .connect(rewardsManager)
+            .approve(rewardsPool.address, allocatedReward)
+          await rewardsPool.connect(rewardsManager).topUpReward(allocatedReward)
+          await increaseTime(rewardInterval)
+          await rewardsPool.withdraw()
+
+          await mineBlock()
+          lastFinalizedBlock = (await lastBlockNumber()) - 1
+        })
+
+        it("should return correct voting power", async () => {
+          // underwriter 1 has 400/600 = 2/3 share of the pool
+          // underwriter 2 has 200/600 = 1/3 share of the pool
+          //
+          // they are rewarded proportionally:
+          //   underwriter 1: 90 * 2/3 = 60
+          //   underwriter 2: 90 * 1/3 = 30
+          //
+          // their voting power should increase:
+          //   underwriter 1: 400 + 60 = 460
+          //   underwriter 2: 200 + 30 = 230
+          expect(
+            await coveragePool.getPastVotes(
+              underwriter1.address,
+              lastFinalizedBlock
+            )
+          ).to.be.closeTo(to1e18(460), assertionPrecision)
+
+          expect(
+            await coveragePool.getPastVotes(
+              underwriter2.address,
+              lastFinalizedBlock
+            )
+          ).to.be.closeTo(to1e18(230), assertionPrecision)
+        })
+      })
+
+      context("when there was a claim", async () => {
+        const portionToSeize = to1ePrecision(1, 17) // 0.1
+
+        beforeEach(async () => {
+          await coveragePool
+            .connect(governance)
+            .approveFirstRiskManager(riskManager.address)
+
+          await coveragePool
+            .connect(riskManager)
+            .seizeFunds(recipient.address, portionToSeize)
+
+          await mineBlock()
+          lastFinalizedBlock = (await lastBlockNumber()) - 1
+        })
+
+        it("should return correct voting power", async () => {
+          // underwriter 1 has 400/600 = 2/3 share of the pool
+          // underwriter 2 has 200/600 = 1/3 share of the pool
+          //
+          // 0.1 of the coverage pool got liquidated
+          // 0.9 * 600 = 540 collateral tokens remain in the pool
+          //
+          // underwriter voting power should decrease:
+          //   underwriter 1: 2/3 * 540 = 360
+          //   underwriter 2: 1/3 * 540 = 180
+          expect(
+            await coveragePool.getPastVotes(
+              underwriter1.address,
+              lastFinalizedBlock
+            )
+          ).to.equal(to1e18(360))
+
+          expect(
+            await coveragePool.getPastVotes(
+              underwriter2.address,
+              lastFinalizedBlock
+            )
+          ).to.equal(to1e18(180))
+        })
       })
     })
   })

--- a/test/CoveragePool.test.js
+++ b/test/CoveragePool.test.js
@@ -488,7 +488,7 @@ describe("CoveragePool", () => {
 
       it("should return zero", async () => {
         expect(
-          await collateralToken.getPastVotes(
+          await coveragePool.getPastVotes(
             thirdParty.address,
             lastFinalizedBlock
           )

--- a/test/CoveragePool.test.js
+++ b/test/CoveragePool.test.js
@@ -477,12 +477,11 @@ describe("CoveragePool", () => {
 
     context("when underwriter did not delegate voting", () => {
       beforeEach(async () => {
-        // Underwriter deposits into the asset pool
-        await collateralToken.mint(underwriter1.address, to1e18(400))
+        await collateralToken.mint(thirdParty.address, to1e18(400))
         await collateralToken
-          .connect(underwriter1)
+          .connect(thirdParty)
           .approve(assetPool.address, to1e18(400))
-        await assetPool.connect(underwriter1).deposit(to1e18(400))
+        await assetPool.connect(thirdParty).deposit(to1e18(400))
 
         lastFinalizedBlock = (await lastBlockNumber()) - 1
       })
@@ -490,7 +489,7 @@ describe("CoveragePool", () => {
       it("should return zero", async () => {
         expect(
           await collateralToken.getPastVotes(
-            underwriter1.address,
+            thirdParty.address,
             lastFinalizedBlock
           )
         ).to.equal(0)
@@ -499,7 +498,6 @@ describe("CoveragePool", () => {
 
     context("when account did not deposit into the pool", () => {
       beforeEach(async () => {
-        // Some other underwriter deposits into the asset pool
         await collateralToken.mint(underwriter1.address, to1e18(400))
         await collateralToken
           .connect(underwriter1)

--- a/test/system/init-contracts.js
+++ b/test/system/init-contracts.js
@@ -55,8 +55,8 @@ async function initContracts(swapStrategy) {
     depositAddress3
   )
 
-  const AssetPool = await ethers.getContractFactory("AssetPool")
-  const assetPool = await AssetPool.deploy(
+  const KeepAssetPool = await ethers.getContractFactory("KeepAssetPool")
+  const assetPool = await KeepAssetPool.deploy(
     keepTokenAddress,
     underwriterToken.address,
     rewardsManager.address

--- a/yarn.lock
+++ b/yarn.lock
@@ -1177,10 +1177,6 @@
     "@openzeppelin/upgrades" "^2.7.2"
     openzeppelin-solidity "2.3.0"
 
-"@keep-network/prettier-config-keep@github:keep-network/prettier-config-keep":
-  version "0.0.1"
-  resolved "https://codeload.github.com/keep-network/prettier-config-keep/tar.gz/a1a333e7ac49928a0f6ed39421906dd1e46ab0f3"
-
 "@keep-network/prettier-config-keep@github:keep-network/prettier-config-keep#d6ec02e":
   version "0.0.1"
   resolved "https://codeload.github.com/keep-network/prettier-config-keep/tar.gz/d6ec02e80dd76edfba073ca58ef99aee39002c2c"
@@ -4506,7 +4502,7 @@ eslint-config-google@^0.13.0:
     eslint-plugin-no-only-tests "^2.3.1"
     eslint-plugin-prettier "^3.1.2"
 
-eslint-config-prettier@^6.15.0:
+eslint-config-prettier@^6.10.0:
   version "6.15.0"
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.15.0.tgz#7f93f6cb7d45a92f1537a70ecc06366e1ac6fed9"
   integrity sha512-a1+kOYLR8wMGustcgAjdydMsQ2A/2ipRPwRKUmfYaSxc9ZPcrku080Ctl6zrZzZNs/U82MjSv+qKREkoq3bJaw==
@@ -6184,6 +6180,11 @@ har-validator@~5.1.3:
   dependencies:
     ajv "^6.12.3"
     har-schema "^2.0.0"
+
+hardhat-dependency-compiler@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/hardhat-dependency-compiler/-/hardhat-dependency-compiler-1.1.2.tgz#02867b7c6dd3de4924d9d3d6593feab8408f1eeb"
+  integrity sha512-LVnsPSZnGvzWVvlpewlkPKlPtFP/S9V41RC1fd/ygZc4jkG8ubNlfE82nwiGw5oPueHSmFi6TACgmyrEOokK8w==
 
 hardhat-deploy@^0.9.1:
   version "0.9.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1143,14 +1143,6 @@
     deepmerge "^4.2.2"
     untildify "^4.0.0"
 
-"@keep-network/keep-core@1.7.0":
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/@keep-network/keep-core/-/keep-core-1.7.0.tgz#0923d539fc431810bd9b239f91e09a92a2b255a0"
-  integrity sha512-jU0ol4L5a7vFUXCTlYGsjZYhl87cUpiAYz9LgDgvM3sGmwNIVZ9dY3gziINXIbSSFZjoqh3eGDxDPcQmA+Rjrg==
-  dependencies:
-    "@openzeppelin/upgrades" "^2.7.2"
-    openzeppelin-solidity "2.4.0"
-
 "@keep-network/keep-core@1.8.0-rc.6":
   version "1.8.0-rc.6"
   resolved "https://registry.yarnpkg.com/@keep-network/keep-core/-/keep-core-1.8.0-rc.6.tgz#a9f6bec312aa8b1bc40f95c8a27c2ba8d09886f7"
@@ -1293,6 +1285,11 @@
   dependencies:
     "@types/sinon-chai" "^3.2.3"
     "@types/web3" "1.0.19"
+
+"@openzeppelin/contracts-upgradeable@^4.4":
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.4.2.tgz#748a5986a02548ef541cabc2ce8c67a890044c40"
+  integrity sha512-bavxs18L47EmcdnL9I6DzsVSUJO+0/zD6zH7/6qG7QRBugvR3VNVZR+nMvuZlCNwuTTnCa3apR00PYzYr/efAw==
 
 "@openzeppelin/contracts@^2.4.0":
   version "2.5.1"
@@ -1592,13 +1589,13 @@
   dependencies:
     "@openzeppelin/contracts" "^4.1.0"
 
-"@threshold-network/solidity-contracts@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@threshold-network/solidity-contracts/-/solidity-contracts-1.0.0.tgz#030f388de2b6ed730fafc2575189797ac5690133"
-  integrity sha512-Y/2FeMAKPZREDvxZC/doIezNW3ScgBb4blAyCrlswhTCmpxofRCuBuEkoaZRMRmvS8aaT0ln47DTzkn6bRq6DQ==
+"@threshold-network/solidity-contracts@github:threshold-network/solidity-contracts#0f07c2f":
+  version "1.1.0-dev"
+  resolved "https://codeload.github.com/threshold-network/solidity-contracts/tar.gz/0f07c2fc06788d5f9d7080e00b42efa63e406690"
   dependencies:
-    "@keep-network/keep-core" "1.7.0"
+    "@keep-network/keep-core" ">1.8.0-dev <1.8.0-pre"
     "@openzeppelin/contracts" "^4.4"
+    "@openzeppelin/contracts-upgradeable" "^4.4"
     "@thesis/solidity-contracts" "github:thesis/solidity-contracts#4985bcf"
 
 "@truffle/error@^0.0.14":

--- a/yarn.lock
+++ b/yarn.lock
@@ -1143,6 +1143,14 @@
     deepmerge "^4.2.2"
     untildify "^4.0.0"
 
+"@keep-network/keep-core@1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@keep-network/keep-core/-/keep-core-1.7.0.tgz#0923d539fc431810bd9b239f91e09a92a2b255a0"
+  integrity sha512-jU0ol4L5a7vFUXCTlYGsjZYhl87cUpiAYz9LgDgvM3sGmwNIVZ9dY3gziINXIbSSFZjoqh3eGDxDPcQmA+Rjrg==
+  dependencies:
+    "@openzeppelin/upgrades" "^2.7.2"
+    openzeppelin-solidity "2.4.0"
+
 "@keep-network/keep-core@1.8.0-rc.6":
   version "1.8.0-rc.6"
   resolved "https://registry.yarnpkg.com/@keep-network/keep-core/-/keep-core-1.8.0-rc.6.tgz#a9f6bec312aa8b1bc40f95c8a27c2ba8d09886f7"
@@ -1304,6 +1312,11 @@
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.3.2.tgz#ff80affd6d352dbe1bbc5b4e1833c41afd6283b6"
   integrity sha512-AybF1cesONZStg5kWf6ao9OlqTZuPqddvprc0ky7lrUVOjXeKpmQ2Y9FK+6ygxasb+4aic4O5pneFBfwVsRRRg==
+
+"@openzeppelin/contracts@^4.4":
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.4.1.tgz#3382db2cd83ab565ed9626765e7da92944b45de8"
+  integrity sha512-o+pHCf/yMLSlV5MkDQEzEQL402i6SoRnktru+0rdSxVEFZcTzzGhZCAtZjUFyKGazMSv1TilzMg+RbED1N8XHQ==
 
 "@openzeppelin/upgrades@^2.7.2":
   version "2.8.0"
@@ -1583,18 +1596,14 @@
   dependencies:
     "@openzeppelin/contracts" "^4.1.0"
 
-"@thesis/solidity-contracts@github:thesis/solidity-contracts#507c647":
-  version "0.0.1"
-  resolved "https://codeload.github.com/thesis/solidity-contracts/tar.gz/507c64759a2783196b505365e0cb4bf13c1ad1fa"
+"@threshold-network/solidity-contracts@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@threshold-network/solidity-contracts/-/solidity-contracts-1.0.0.tgz#030f388de2b6ed730fafc2575189797ac5690133"
+  integrity sha512-Y/2FeMAKPZREDvxZC/doIezNW3ScgBb4blAyCrlswhTCmpxofRCuBuEkoaZRMRmvS8aaT0ln47DTzkn6bRq6DQ==
   dependencies:
-    "@openzeppelin/contracts" "^4.1.0"
-
-"@threshold-network/solidity-contracts@github:threshold-network/solidity-contracts#6664c73":
-  version "0.0.1"
-  resolved "https://codeload.github.com/threshold-network/solidity-contracts/tar.gz/6664c738660f79de3add7fdff735fcb19d5165ad"
-  dependencies:
-    "@openzeppelin/contracts" "^4.3"
-    "@thesis/solidity-contracts" "github:thesis/solidity-contracts#507c647"
+    "@keep-network/keep-core" "1.7.0"
+    "@openzeppelin/contracts" "^4.4"
+    "@thesis/solidity-contracts" "github:thesis/solidity-contracts#4985bcf"
 
 "@truffle/error@^0.0.14":
   version "0.0.14"
@@ -4492,9 +4501,8 @@ eslint-config-google@^0.13.0:
   version "0.3.0"
   resolved "https://codeload.github.com/keep-network/eslint-config-keep/tar.gz/0c27ade54e725f980e971c3d91ea88bab76b2330"
   dependencies:
-    "@keep-network/prettier-config-keep" "github:keep-network/prettier-config-keep"
     eslint-config-google "^0.13.0"
-    eslint-config-prettier "^6.15.0"
+    eslint-config-prettier "^6.10.0"
     eslint-plugin-no-only-tests "^2.3.1"
     eslint-plugin-prettier "^3.1.2"
 


### PR DESCRIPTION
~~Depends on #202~~
~~Marking this PR as a draft until ^ is merged.~~

In #199 we added support for DAO `Checkpoints` to `UnderwriterToken` contract (COV token). This is not enough to enable DAO support in coverage pools - we know one's voting power proportional to COV supply but T DAO needs to know one's voting power proportional to T supply.

To make it happen, `CoveragePool.getPastVotes(address account, uint256 blockNumber)` implemented in this PR computes underwriter's voting power as underwriter's coverage pool share multiplied by the amount of T coverage pool has. This approach takes into account liquidations and rewards emitted to the coverage pool.

To participate in DAO, the underwriter needs to delegate their COV voting power to someone (or self-delegate), just like in the case of T liquid holders.

### Example 1

- Underwriter 1 deposited 400 T into the coverage pool.
- Underwriter 2 deposited 200 T into the coverage pool.
- Coverage Pool has 600 T.

Underwriter 1 voting power is 400, Underwriter 2 voting power is 200.

### Example 2

- Underwriter 1 deposited 400 T into the coverage pool.
- Underwriter 2 deposited 200 T into the coverage pool.
- Coverage pool has 600 T.
- Underwriter 1 withdrew 100 T from the Coverage Pool.

Underwriter 1 voting power is 300, Underwriter 2 voting power is 200.

### Example 3

- Underwriter 1 deposited 400 T into the coverage pool.
- Underwriter 2 deposited 200 T into the coverage pool.
- 90 T was allocated to the coverage pool as rewards.
- Coverage Pool has 690 T.

Underwriter 1 voting power is 460, Underwriter 2 voting power is 230.

### Example 4

- Underwriter 1 deposited 400 T into the coverage pool.
- Underwriter 2 deposited 200 T into the coverage pool.
- 60 T was liquidated from the coverage pool by the risk manager.
- Coverage pool has 540 T.

Underwriter 1 voting power is 360, Underwriter 2 voting power is 180.