### PR TITLE
Bump-up version of tbtc and t contracts dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
   },
   "dependencies": {
     "@keep-network/keep-core": ">1.8.0-dev <1.8.0-pre",
-    "@keep-network/tbtc": ">1.1.2-dev <1.1.2-ropsten",
+    "@keep-network/tbtc": ">1.1.2-dev <1.1.2-pre",
     "@thesis/solidity-contracts": "github:thesis/solidity-contracts#4985bcf",
-    "@threshold-network/solidity-contracts": "github:threshold-network/solidity-contracts#6664c73",
+    "@threshold-network/solidity-contracts": ">1.1.0-dev <1.1.0-ropsten",
     "@openzeppelin/contracts": "^4.3",
     "@tenderly/hardhat-tenderly": "^1.0.12"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1143,10 +1143,10 @@
     deepmerge "^4.2.2"
     untildify "^4.0.0"
 
-"@keep-network/keep-core@1.8.0-rc.6":
-  version "1.8.0-rc.6"
-  resolved "https://registry.yarnpkg.com/@keep-network/keep-core/-/keep-core-1.8.0-rc.6.tgz#a9f6bec312aa8b1bc40f95c8a27c2ba8d09886f7"
-  integrity sha512-hGBwreQA636Gqgd0pIFNhPDSf9qq83MipQftRkGskeNb8TePJu07fJ2Almb9EUrsBG57E0SCo9VpugQCGVnibA==
+"@keep-network/keep-core@1.8.0-dev.5":
+  version "1.8.0-dev.5"
+  resolved "https://registry.yarnpkg.com/@keep-network/keep-core/-/keep-core-1.8.0-dev.5.tgz#8b4d08ec437f29c94723ee54fcf76456ba5408c3"
+  integrity sha512-QVkpO5X28Vczj/xHezV0z2UuMw8QFaR3C8x/d6+3adedsL3nCxgveIGTUcXSuYpBqfx0v4/xT+9bIK7BwLkGPw==
   dependencies:
     "@openzeppelin/upgrades" "^2.7.2"
     openzeppelin-solidity "2.4.0"
@@ -1159,13 +1159,13 @@
     "@openzeppelin/upgrades" "^2.7.2"
     openzeppelin-solidity "2.4.0"
 
-"@keep-network/keep-ecdsa@1.7.0-rc.4":
-  version "1.7.0-rc.4"
-  resolved "https://registry.yarnpkg.com/@keep-network/keep-ecdsa/-/keep-ecdsa-1.7.0-rc.4.tgz#8460527ad22fb42b3c47492bd0cb45305873393e"
-  integrity sha512-87WgfQkfK854oCjW3h8otT3h/B0vM4P/TUBK4TfgJH8knzY8FPnxwemNp+PQN5W60dezfdTahylM/bQvgLkljg==
+"@keep-network/keep-ecdsa@>1.9.0-dev <1.9.0-ropsten":
+  version "1.9.0-dev.0"
+  resolved "https://registry.yarnpkg.com/@keep-network/keep-ecdsa/-/keep-ecdsa-1.9.0-dev.0.tgz#02be0c363099f40006d1ec3ac851e6aab5aede69"
+  integrity sha512-qkm7pEZYWQmkH5ppQz4azijxwV2jzPeeSQktkHw9Fa2w2GGkgfRuHVl8LYaPimtEYrvx5t2m0LAvmI7zlRQ4Lg==
   dependencies:
-    "@keep-network/keep-core" "1.8.0-rc.6"
-    "@keep-network/sortition-pools" ">1.2.0-pre <1.2.0-rc"
+    "@keep-network/keep-core" "1.8.0-dev.5"
+    "@keep-network/sortition-pools" "1.2.0-dev.1"
     "@openzeppelin/upgrades" "^2.7.2"
     openzeppelin-solidity "2.3.0"
 
@@ -1177,20 +1177,20 @@
   version "0.0.1"
   resolved "https://codeload.github.com/keep-network/prettier-config-keep/tar.gz/d6ec02e80dd76edfba073ca58ef99aee39002c2c"
 
-"@keep-network/sortition-pools@>1.2.0-pre <1.2.0-rc":
-  version "1.2.0-pre.6"
-  resolved "https://registry.yarnpkg.com/@keep-network/sortition-pools/-/sortition-pools-1.2.0-pre.6.tgz#d526c0c8cde16bd4f027805b93d993028dbfcf98"
-  integrity sha512-6Tusle8KGZldO8jbFDfxChdgI6hMpTAW4LG+cAkf7jgRR48o6NkUiA7mDoWk/+dlitpHrQpWT1JM4N7aR/4/EQ==
+"@keep-network/sortition-pools@1.2.0-dev.1":
+  version "1.2.0-dev.1"
+  resolved "https://registry.yarnpkg.com/@keep-network/sortition-pools/-/sortition-pools-1.2.0-dev.1.tgz#2ee371f1dd1ff71f6d05c9ddc2a83a4a93ff56b3"
+  integrity sha512-CaOsvxNWHgXRFwPThDn3C/LiCwq9pL8ICLXXkysRSLw1Hx69wLnToaXYuwyXeIEy5pGqe5+288DBIqvJ3T4+jA==
   dependencies:
     "@openzeppelin/contracts" "^2.4.0"
 
-"@keep-network/tbtc@>1.1.2-dev <1.1.2-ropsten":
-  version "1.1.2-rc.3"
-  resolved "https://registry.yarnpkg.com/@keep-network/tbtc/-/tbtc-1.1.2-rc.3.tgz#6e7c356a1924849cbc77cf5fc740dddc8b97b8e9"
-  integrity sha512-BG8YMqzvsXkjTPi3u3ELAEV2c26PP9rzztkeUBNYwO7CyFATE5eB0o2JFt3K4r/ADyVUBVv1mEi2bePyUX530g==
+"@keep-network/tbtc@>1.1.2-dev <1.1.2-pre":
+  version "1.1.2-dev.0"
+  resolved "https://registry.yarnpkg.com/@keep-network/tbtc/-/tbtc-1.1.2-dev.0.tgz#52f61f6455406c2d3650d9f14cc3d734fe2addab"
+  integrity sha512-G/JbDht/IgdX8Ety0i0iUl+kB2J2ofiAmNw+HmN/YUN9BYFhhzQqltPtYjS/krBkWzBYmNJmZBFeX/h+q4EJvA==
   dependencies:
     "@celo/contractkit" "^1.0.2"
-    "@keep-network/keep-ecdsa" "1.7.0-rc.4"
+    "@keep-network/keep-ecdsa" ">1.9.0-dev <1.9.0-ropsten"
     "@summa-tx/bitcoin-spv-sol" "^3.1.0"
     "@summa-tx/relay-sol" "^2.0.2"
     openzeppelin-solidity "2.3.0"
@@ -1304,6 +1304,11 @@
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.3.2.tgz#ff80affd6d352dbe1bbc5b4e1833c41afd6283b6"
   integrity sha512-AybF1cesONZStg5kWf6ao9OlqTZuPqddvprc0ky7lrUVOjXeKpmQ2Y9FK+6ygxasb+4aic4O5pneFBfwVsRRRg==
+
+"@openzeppelin/contracts@^4.4":
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.4.2.tgz#4e889c9c66e736f7de189a53f8ba5b8d789425c2"
+  integrity sha512-NyJV7sJgoGYqbtNUWgzzOGW4T6rR19FmX1IJgXGdapGPWsuMelGJn9h03nos0iqfforCbCB0iYIR0MtIuIFLLw==
 
 "@openzeppelin/upgrades@^2.7.2":
   version "2.8.0"
@@ -1583,18 +1588,14 @@
   dependencies:
     "@openzeppelin/contracts" "^4.1.0"
 
-"@thesis/solidity-contracts@github:thesis/solidity-contracts#507c647":
-  version "0.0.1"
-  resolved "https://codeload.github.com/thesis/solidity-contracts/tar.gz/507c64759a2783196b505365e0cb4bf13c1ad1fa"
+"@threshold-network/solidity-contracts@>1.1.0-dev <1.1.0-ropsten":
+  version "1.1.0-dev.1"
+  resolved "https://registry.yarnpkg.com/@threshold-network/solidity-contracts/-/solidity-contracts-1.1.0-dev.1.tgz#c6c662aa5479592b8899a7b703745da7563a925e"
+  integrity sha512-2Qxho8mExTihE1UCXSIs5He4WBD0UumUa66ze6/in9l/UZW9ZTXcGI5hQssa3WkHps+74DUykFcRFYrKC4w1DA==
   dependencies:
-    "@openzeppelin/contracts" "^4.1.0"
-
-"@threshold-network/solidity-contracts@github:threshold-network/solidity-contracts#6664c73":
-  version "0.0.1"
-  resolved "https://codeload.github.com/threshold-network/solidity-contracts/tar.gz/6664c738660f79de3add7fdff735fcb19d5165ad"
-  dependencies:
-    "@openzeppelin/contracts" "^4.3"
-    "@thesis/solidity-contracts" "github:thesis/solidity-contracts#507c647"
+    "@keep-network/keep-core" ">1.8.0-dev <1.8.0-pre"
+    "@openzeppelin/contracts" "^4.4"
+    "@thesis/solidity-contracts" "github:thesis/solidity-contracts#4985bcf"
 
 "@truffle/error@^0.0.14":
   version "0.0.14"


### PR DESCRIPTION
We recently published first `-dev` suffixed npm package for
`@keep-network/tbtc` (`1.1.2-dev.0`) and started publishing npm
packages for @threshold-network/solidity-contracts.
Now we want to update the dependencies in  `coverage-pools` to
reflect that change.