### PR TITLE
Ignore `external` directory in git and linters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ build/
 cache/
 deployments/
 export.json
+external/
 
 typechain/
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,6 +2,7 @@ artifacts/
 build/
 cache/
 deployments/
+external/
 typechain/
 export.json
 hardhat-dependency-compiler/

--- a/.solhintignore
+++ b/.solhintignore
@@ -1,2 +1,3 @@
 node_modules/
 hardhat-dependency-compiler/
+external/


### PR DESCRIPTION
An `external/npm/@keep-network/keep-core/artifacts` directory is created
every time the `threshold-network/solidity-contracts` dependency is
installed. This is due to a workaround in
`threshold-network/solidity-contracts` which allows us to use contracts
which come from different repos and share the same name. Creation of
the `external` folder is a by-product of that. We don't need to track
changes in that folder or run linters on its files.