### PR TITLE
Use `development` instead of `dev` to tag published npm package

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -44,4 +44,4 @@ jobs:
       - name: Publish package
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access=public --network=hardhat --tag=dev
+        run: npm publish --access=public --network=hardhat --tag=development


### PR DESCRIPTION
We're changing the name to unify tags used during publish step in
various CI workflows. In most places we use `development` tag for
tagging packages meant for development environment, so we're
changing the tagging here to follow the same pattern.
In previous change to this line I misidentified prevalent tag and
wrongly changed it from `development` to `dev`.