### PR TITLE
Update GHA workflows

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -159,12 +159,13 @@ jobs:
       - name: Install needed dependencies
         run: yarn install --frozen-lockfile
 
-      # If we don't remove the `keep-core` and `tbtc` contracts from `node-modules`,
-      # the `etherscan-verify` plugins tries to verify them, which is not desired.
+      # If we don't remove the dependencies' contracts from `node-modules`, the
+      # `etherscan-verify` plugins tries to verify them, which is not desired.
       - name: Prepare for verification on Etherscan
         run: |
           rm -rf ./node_modules/@keep-network/keep-core
           rm -rf ./node_modules/@keep-network/tbtc
+          rm -rf ./node_modules/@threshold-network/solidity-contracts
 
       - name: Verify contracts on Etherscan
         env:

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -218,7 +218,7 @@ jobs:
 
       - name: Install Slither
         env:
-          SLITHER_VERSION: 0.8.0
+          SLITHER_VERSION: 0.8.3
         run: pip3 install slither-analyzer==$SLITHER_VERSION
 
       - name: Install dependencies

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -6,6 +6,8 @@ on:
       - main
     paths:
       - "contracts/**"
+      - "deploy/**"
+      - "hardhat.config.ts"
       - "package.json"
       - "yarn.lock"
   workflow_dispatch:


### PR DESCRIPTION
In this PR we're introducing various changes to the GH Actions workflows:
- Update slither to the latest version
- Remove `@threshold-network/solidity-contracts` files before etherscan verification on testnet
- Expand NPM workflow triggers

Similar changes in other projects:
https://github.com/keep-network/keep-core/pull/2957
https://github.com/keep-network/tbtc-v2/pull/230