### PR TITLE
Add the status badge to README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -2,6 +2,8 @@
 
 = Coverage pool
 
+https://github.com/keep-network/coverage-pools/actions/workflows/contracts.yml[image:https://img.shields.io/github/workflow/status/keep-network/coverage-pools/Solidity/main?event=push&label=Coverage%20pool%20contracts%20build[Coverage pool contracts build status]]
+
 A governable, fee-earning asset pool to cover low-likelihood on-chain events.
 
 toc::[]


### PR DESCRIPTION
We're adding a badge to the README file which shows the status of the workflow building and testing the Solidity code in the `coverage-pool` repository. The displayed status is based the status of the most recently executed `Solidity` workflow triggered by the push to `main`.