### PR TITLE
Fix slither job by upgrading Python to 13.10.8

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -207,7 +207,7 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.8.5
+          python-version: 3.10.8
 
       - name: Install Solidity
         env:


### PR DESCRIPTION
The `ubuntu-latest` runner used by us to run GH Actions jobs is getting migrated from Ubuntu `20.04` to `22.04`
(https://github.com/actions/runner-images/issues/6399). The `22.04` version does not work with the config of the `actions/setup-python@v4` action which we use in the jobs running slither. We were getting following failures in workflows:
```
Version 3.8.5 was not found in the local cache
Error: Version 3.8.5 with arch x64 not found
The list of all available versions can be found here:
https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
```
Based on https://github.com/actions/setup-python/issues/555, we should upgrade Python version to `3.9.12` or higher. Or we could configure job to run on the hardcoded Ubuntu `20.04` runner.
According to Slither documentation `Slither requires Python 3.8+ and solc, the Solidity compiler`, so upgrading to latest Python version (`3.11.0`) should be ok. We tried using this version, but another issue occurred: https://github.com/crytic/slither/issues/1466. As recommended in the comments, we downgraded the Python version (to `3.10.8`, which is supported on Ubuntu `22.04`).

Refs:
https://github.com/keep-network/keep-core/pull/3432
https://github.com/keep-network/tbtc-v2/pull/423
https://github.com/threshold-network/solidity-contracts/pull/131