### PR TITLE
Fix badges after change in shields.io syntax

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -2,7 +2,7 @@
 
 = Coverage pool
 
-https://github.com/keep-network/coverage-pools/actions/workflows/contracts.yml[image:https://img.shields.io/github/workflow/status/keep-network/coverage-pools/Solidity/main?event=push&label=Coverage%20pool%20contracts%20build[Coverage pool contracts build status]]
+https://github.com/keep-network/coverage-pools/actions/workflows/contracts.yml[image:https://img.shields.io/github/actions/workflow/status/keep-network/coverage-pools/contracts.yml?branch=main&event=push&label=Coverage%20pool%20contracts%20build[Coverage pool contracts build status]]
 
 A governable, fee-earning asset pool to cover low-likelihood on-chain events.
 


### PR DESCRIPTION
The `shields.io` have changed the syntax of the endpoints generating status badges, resulting in showing false failure status when old syntax was used. Updating the READMEs to use the new syntax.
Read more: badges/shields#8671.

Refs:
https://github.com/keep-network/keep-common/pull/112
https://github.com/keep-network/sortition-pools/pull/198
https://github.com/keep-network/keep-core/pull/3449
https://github.com/keep-network/tbtc-v2/pull/429