### PR TITLE
Allow the risk manager to seize the exact amount

### DIFF
--- a/contracts/AssetPool.sol
+++ b/contracts/AssetPool.sol
@@ -430,6 +430,10 @@ contract AssetPool is Ownable, IAssetPool {
     function claim(address recipient, uint256 amount) external onlyOwner {
         emit CoverageClaimed(recipient, amount, block.timestamp);
         rewardsPool.withdraw();
+        require(
+            amount <= collateralToken.balanceOf(address(this)),
+            "Amount to seize exceeds the pool balance"
+        );
         collateralToken.safeTransfer(recipient, amount);
     }
 

--- a/contracts/Auctioneer.sol
+++ b/contracts/Auctioneer.sol
@@ -98,7 +98,7 @@ contract Auctioneer is CloneFactory {
         // defined in Auction.sol
         //
         //slither-disable-next-line reentrancy-no-eth,reentrancy-events,reentrancy-benign
-        coveragePool.seizeFunds(offerTaker, portionToSeize);
+        coveragePool.seizePortion(offerTaker, portionToSeize);
 
         Auction auction = Auction(msg.sender);
         if (fullyFilled) {

--- a/contracts/CoveragePool.sol
+++ b/contracts/CoveragePool.sol
@@ -202,15 +202,15 @@ contract CoveragePool is Ownable {
         assetPool.finalizeWithdrawalTimeoutUpdate();
     }
 
-    /// @notice Seizes funds from the coverage pool and puts them aside for the
-    ///         recipient to withdraw.
+    /// @notice Seizes funds from the coverage pool and sends them to the
+    ///         `recipient`.
     /// @dev `portionToSeize` value was multiplied by `FLOATING_POINT_DIVISOR`
     ///      for calculation precision purposes. Further calculations in this
     ///      function will need to take this divisor into account.
     /// @param recipient Address that will receive the pool's seized funds
     /// @param portionToSeize Portion of the pool to seize in the range (0, 1]
     ///        multiplied by `FLOATING_POINT_DIVISOR`
-    function seizeFunds(address recipient, uint256 portionToSeize)
+    function seizePortion(address recipient, uint256 portionToSeize)
         external
         onlyApprovedRiskManager
     {
@@ -221,6 +221,20 @@ contract CoveragePool is Ownable {
         );
 
         assetPool.claim(recipient, amountToSeize(portionToSeize));
+    }
+
+    /// @notice Seizes funds from the coverage pool and sends them to the
+    ///         `recipient`.
+    /// @param recipient Address that will receive the pool's seized funds
+    /// @param amountToSeize Amount to be seized from the pool
+    // slither-disable-next-line shadowing-local
+    function seizeAmount(address recipient, uint256 amountToSeize)
+        external
+        onlyApprovedRiskManager
+    {
+        require(amountToSeize > 0, "Amount to seize must be >0");
+
+        assetPool.claim(recipient, amountToSeize);
     }
 
     /// @notice Grants asset pool shares by minting a given amount of the

--- a/contracts/test/CoveragePoolStub.sol
+++ b/contracts/test/CoveragePoolStub.sol
@@ -6,11 +6,11 @@ import "../CoveragePoolConstants.sol";
 contract CoveragePoolStub {
     uint256 public covTotalSupply;
 
-    event FundsSeized(address indexed recipient, uint256 portionToSeize);
+    event PortionSeized(address indexed recipient, uint256 portionToSeize);
     event AssetPoolSharesGranted(address indexed recipient, uint256 covAmount);
 
-    function seizeFunds(address recipient, uint256 portionToSeize) external {
-        emit FundsSeized(recipient, portionToSeize);
+    function seizePortion(address recipient, uint256 portionToSeize) external {
+        emit PortionSeized(recipient, portionToSeize);
     }
 
     function grantAssetPoolShares(address recipient, uint256 covAmount)

--- a/test/Auctioneer.test.js
+++ b/test/Auctioneer.test.js
@@ -161,9 +161,9 @@ describe("Auctioneer", () => {
         })
 
         it("should seize funds from coverage pool", async () => {
-          // assert SeizeFunds emitted with the right values
-          // check whether seizeFunds was executed with the right params
-          events = pastEvents(receipt1, coveragePoolStub, "FundsSeized")
+          // assert PortionSeized emitted with the right values
+          // check whether seizePortion was executed with the right params
+          events = pastEvents(receipt1, coveragePoolStub, "PortionSeized")
           expect(events.length).to.equal(1)
           expect(events[0].args["recipient"]).to.equal(bidder.address)
           expect(events[0].args["portionToSeize"]).to.be.closeTo(
@@ -221,8 +221,8 @@ describe("Auctioneer", () => {
       })
 
       it("should seize funds from coverage pool", async () => {
-        // assert SeizeFunds emitted with the right values
-        events = pastEvents(receipt, coveragePoolStub, "FundsSeized")
+        // assert PortionSeized emitted with the right values
+        events = pastEvents(receipt, coveragePoolStub, "PortionSeized")
         expect(events.length).to.equal(1)
         expect(events[0].args["recipient"]).to.equal(bidder.address)
         expect(events[0].args["portionToSeize"]).to.be.closeTo(


### PR DESCRIPTION
According to the recent DAO proposal (TIP-043), the Treasury Guild multisig should be able to claim coverage from the pool. In v1, the coverage was claimed by an automated `RiskManagerV1` running an auction and seizing (0,1] portion of the pool. This approach was fine for an automated dutch auction but for v2, the Risk Manager (Treasury Guild Multisig) should be able to claim an exact amount.

For this reason, the existing `seizeFunds` has been renamed to `seizePortion` and a new function, `seizeAmount` is introduced. `seizeAmount` allows the authorized Risk Manager to claim an exact amount of coverage.

See https://forum.threshold.network/t/tip-043-coverage-pool-migration/465