### PR TITLE
Batched Phased Escrow

### DIFF
--- a/contracts/BatchedPhasedEscrow.sol
+++ b/contracts/BatchedPhasedEscrow.sol
@@ -45,7 +45,7 @@ contract BatchedPhasedEscrow is Ownable {
         _;
     }
 
-    constructor(IERC20 _token) public {
+    constructor(IERC20 _token) {
         token = _token;
         drawee = msg.sender;
     }
@@ -77,7 +77,7 @@ contract BatchedPhasedEscrow is Ownable {
 
     /// @notice Transfers the role of drawee to another address. Can be called
     ///         only by the contract owner.
-    function setDrawee(address newDrawee) public onlyOwner {
+    function setDrawee(address newDrawee) external onlyOwner {
         require(newDrawee != address(0), "New drawee can not be zero address");
         emit DraweeRoleTransferred(drawee, newDrawee);
         drawee = newDrawee;
@@ -90,7 +90,7 @@ contract BatchedPhasedEscrow is Ownable {
         uint256 _value,
         address _token,
         bytes memory
-    ) public {
+    ) external {
         require(IERC20(_token) == token, "Unsupported token");
         token.safeTransferFrom(_from, address(this), _value);
     }
@@ -102,7 +102,7 @@ contract BatchedPhasedEscrow is Ownable {
     function batchedWithdraw(
         IBeneficiaryContract[] memory beneficiaries,
         uint256[] memory amounts
-    ) public onlyDrawee {
+    ) external onlyDrawee {
         require(
             beneficiaries.length == amounts.length,
             "Mismatched arrays length"
@@ -121,8 +121,9 @@ contract BatchedPhasedEscrow is Ownable {
     function withdraw(IBeneficiaryContract beneficiary, uint256 amount)
         private
     {
-        token.safeTransfer(address(beneficiary), amount);
         emit TokensWithdrawn(address(beneficiary), amount);
+        token.safeTransfer(address(beneficiary), amount);
+        // slither-disable-next-line calls-loop
         beneficiary.__escrowSentTokens(amount);
     }
 }

--- a/contracts/BatchedPhasedEscrow.sol
+++ b/contracts/BatchedPhasedEscrow.sol
@@ -1,0 +1,128 @@
+// ▓▓▌ ▓▓ ▐▓▓ ▓▓▓▓▓▓▓▓▓▓▌▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▄
+// ▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▌▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
+//   ▓▓▓▓▓▓    ▓▓▓▓▓▓▓▀    ▐▓▓▓▓▓▓    ▐▓▓▓▓▓   ▓▓▓▓▓▓     ▓▓▓▓▓   ▐▓▓▓▓▓▌   ▐▓▓▓▓▓▓
+//   ▓▓▓▓▓▓▄▄▓▓▓▓▓▓▓▀      ▐▓▓▓▓▓▓▄▄▄▄         ▓▓▓▓▓▓▄▄▄▄         ▐▓▓▓▓▓▌   ▐▓▓▓▓▓▓
+//   ▓▓▓▓▓▓▓▓▓▓▓▓▓▀        ▐▓▓▓▓▓▓▓▓▓▓         ▓▓▓▓▓▓▓▓▓▓         ▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
+//   ▓▓▓▓▓▓▀▀▓▓▓▓▓▓▄       ▐▓▓▓▓▓▓▀▀▀▀         ▓▓▓▓▓▓▀▀▀▀         ▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▀
+//   ▓▓▓▓▓▓   ▀▓▓▓▓▓▓▄     ▐▓▓▓▓▓▓     ▓▓▓▓▓   ▓▓▓▓▓▓     ▓▓▓▓▓   ▐▓▓▓▓▓▌
+// ▓▓▓▓▓▓▓▓▓▓ █▓▓▓▓▓▓▓▓▓ ▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓  ▓▓▓▓▓▓▓▓▓▓
+// ▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓ ▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓  ▓▓▓▓▓▓▓▓▓▓
+//
+//                           Trust math, not hardware.
+
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.9;
+
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+/// @title Batched Phased Escrow Beneficiary
+/// @notice Interface expected from contracts receiving tokens from the
+///         BatchedPhasedEscrow.
+interface IBeneficiaryContract {
+    function __escrowSentTokens(uint256 amount) external;
+}
+
+/// @title BatchedPhasedEscrow
+/// @notice A token holder contract allowing contract owner to approve a set of
+///         beneficiaries of tokens held by the contract, to appoint a separate
+///         drawee role, and allowing that drawee to withdraw tokens to approved
+///         beneficiaries in phases.
+contract BatchedPhasedEscrow is Ownable {
+    using SafeERC20 for IERC20;
+
+    event BeneficiaryApproved(address beneficiary);
+    event TokensWithdrawn(address beneficiary, uint256 amount);
+    event DraweeRoleTransferred(address oldDrawee, address newDrawee);
+
+    IERC20 public token;
+    address public drawee;
+    mapping(address => bool) private approvedBeneficiaries;
+
+    modifier onlyDrawee() {
+        require(drawee == msg.sender, "Caller is not the drawee");
+        _;
+    }
+
+    constructor(IERC20 _token) public {
+        token = _token;
+        drawee = msg.sender;
+    }
+
+    /// @notice Approves the provided address as a beneficiary of tokens held by
+    ///         the escrow. Can be called only by escrow owner.
+    function approveBeneficiary(IBeneficiaryContract _beneficiary)
+        external
+        onlyOwner
+    {
+        address beneficiaryAddress = address(_beneficiary);
+        require(
+            beneficiaryAddress != address(0),
+            "Beneficiary can not be zero address"
+        );
+        approvedBeneficiaries[beneficiaryAddress] = true;
+        emit BeneficiaryApproved(beneficiaryAddress);
+    }
+
+    /// @notice Returns `true` if the given address has been approved as a
+    ///         beneficiary of the escrow, `false` otherwise.
+    function isBeneficiaryApproved(IBeneficiaryContract _beneficiary)
+        public
+        view
+        returns (bool)
+    {
+        return approvedBeneficiaries[address(_beneficiary)];
+    }
+
+    /// @notice Transfers the role of drawee to another address. Can be called
+    ///         only by the contract owner.
+    function setDrawee(address newDrawee) public onlyOwner {
+        require(newDrawee != address(0), "New drawee can not be zero address");
+        emit DraweeRoleTransferred(drawee, newDrawee);
+        drawee = newDrawee;
+    }
+
+    /// @notice Funds the escrow by transferring all of the approved tokens
+    ///         to the escrow.
+    function receiveApproval(
+        address _from,
+        uint256 _value,
+        address _token,
+        bytes memory
+    ) public {
+        require(IERC20(_token) == token, "Unsupported token");
+        token.safeTransferFrom(_from, address(this), _value);
+    }
+
+    /// @notice Withdraws tokens from escrow to selected beneficiaries,
+    ///         transferring to each beneficiary the amount of tokens specified
+    ///         as a parameter. Only beneficiaries previously approved by escrow
+    ///         owner can receive funds.
+    function batchedWithdraw(
+        IBeneficiaryContract[] memory beneficiaries,
+        uint256[] memory amounts
+    ) public onlyDrawee {
+        require(
+            beneficiaries.length == amounts.length,
+            "Mismatched arrays length"
+        );
+
+        for (uint256 i = 0; i < beneficiaries.length; i++) {
+            IBeneficiaryContract beneficiary = beneficiaries[i];
+            require(
+                isBeneficiaryApproved(beneficiary),
+                "Beneficiary was not approved"
+            );
+            withdraw(beneficiary, amounts[i]);
+        }
+    }
+
+    function withdraw(IBeneficiaryContract beneficiary, uint256 amount)
+        private
+    {
+        token.safeTransfer(address(beneficiary), amount);
+        emit TokensWithdrawn(address(beneficiary), amount);
+        beneficiary.__escrowSentTokens(amount);
+    }
+}

--- a/contracts/CoveragePoolBeneficiary.sol
+++ b/contracts/CoveragePoolBeneficiary.sol
@@ -15,21 +15,15 @@
 pragma solidity 0.8.9;
 
 import "./RewardsPool.sol";
+import "./BatchedPhasedEscrow.sol";
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
-// CoveragePoolBeneficiary has to comply with IBeneficiaryContract originated
-// from https://github.com/keep-network/keep-core/blob/main/solidity/contracts/PhasedEscrow.sol
-interface IBeneficiaryContract {
-    function __escrowSentTokens(uint256 amount) external;
-}
-
 /// @title CoveragePoolBeneficiary
 /// @notice A beneficiary contract that can receive a withdrawal phase from a
-///         BatchedPhasedEscrow contract deployed at
-///         https://etherscan.io/address/0x1b8e50ec9fbf844c3671bc178df8eadfcff831ca
+///         BatchedPhasedEscrow contract.
 ///         It immediately transfers the received tokens on a designated
 ///         RewardsPool contract.
 contract CoveragePoolBeneficiary is Ownable, IBeneficiaryContract {

--- a/contracts/test/TestSimpleBeneficiary.sol
+++ b/contracts/test/TestSimpleBeneficiary.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.9;
+
+// Simple beneficiary that does nothing when notified that it has received
+// tokens.
+contract TestSimpleBeneficiary {
+    function __escrowSentTokens(uint256 amount) external {}
+}

--- a/test/BatchedPhasedEscrow.test.js
+++ b/test/BatchedPhasedEscrow.test.js
@@ -1,0 +1,334 @@
+const { expect } = require("chai")
+const { ethers } = require("hardhat")
+const { to1e18, ZERO_ADDRESS } = require("./helpers/contract-test-helpers")
+
+describe("BatchedPhasedEscrow", () => {
+  let owner
+  let tokenHolder
+  let drawee
+  let updatedOwner
+  let updatedDrawee
+
+  let token
+  let batchedPhasedEscrow
+
+  let beneficiary1
+  let beneficiary2
+  let beneficiary3
+
+  beforeEach(async () => {
+    owner = await ethers.getSigner(0)
+    tokenHolder = await ethers.getSigner(1)
+    drawee = await ethers.getSigner(2)
+    updatedOwner = await ethers.getSigner(3)
+    updatedDrawee = await ethers.getSigner(4)
+
+    const T = await ethers.getContractFactory("T")
+    token = await T.deploy()
+    await token.deployed()
+
+    await token.connect(owner).mint(tokenHolder.address, to1e18(100000))
+
+    const BatchedPhasedEscrow = await ethers.getContractFactory(
+      "BatchedPhasedEscrow"
+    )
+    batchedPhasedEscrow = await BatchedPhasedEscrow.deploy(token.address)
+    await batchedPhasedEscrow.deployed()
+
+    const TestSimpleBeneficiary = await ethers.getContractFactory(
+      "TestSimpleBeneficiary"
+    )
+    beneficiary1 = await TestSimpleBeneficiary.deploy()
+    beneficiary2 = await TestSimpleBeneficiary.deploy()
+    beneficiary3 = await TestSimpleBeneficiary.deploy()
+
+    await beneficiary1.deployed()
+    await beneficiary2.deployed()
+    await beneficiary3.deployed()
+  })
+
+  describe("receiveApproval", async () => {
+    it("fails for an unknown token", async () => {
+      // It is another T contract deployment, not the one PhasedEscrow was
+      // created with.
+      const T = await ethers.getContractFactory("T")
+      const unknownToken = await T.deploy()
+      await unknownToken.deployed()
+
+      await expect(
+        unknownToken
+          .connect(tokenHolder)
+          .approveAndCall(batchedPhasedEscrow.address, 9991, "0x00")
+      ).to.be.revertedWith("Unsupported token")
+    })
+
+    it("transfers all approved tokens", async () => {
+      const amountApproved = 9993
+      await token
+        .connect(tokenHolder)
+        .approveAndCall(batchedPhasedEscrow.address, amountApproved, "0x00")
+
+      const actualBalance = await token.balanceOf(batchedPhasedEscrow.address)
+      expect(actualBalance).to.eq(amountApproved)
+    })
+  })
+
+  describe("beneficiary approval", async () => {
+    it("can be done by owner", async () => {
+      await batchedPhasedEscrow
+        .connect(owner)
+        .approveBeneficiary(beneficiary1.address)
+      // ok, no revert
+    })
+
+    it("can be done by updated owner", async () => {
+      await batchedPhasedEscrow
+        .connect(owner)
+        .transferOwnership(updatedOwner.address)
+
+      await expect(
+        batchedPhasedEscrow
+          .connect(owner)
+          .approveBeneficiary(beneficiary1.address)
+      ).to.be.revertedWith("Ownable: caller is not the owner")
+      await batchedPhasedEscrow
+        .connect(updatedOwner)
+        .approveBeneficiary(beneficiary1.address)
+      // ok, no revert
+    })
+
+    it("can not be done by non-owner", async () => {
+      await expect(
+        batchedPhasedEscrow
+          .connect(drawee)
+          .approveBeneficiary(beneficiary1.address)
+      ).to.be.revertedWith("Ownable: caller is not the owner")
+    })
+
+    it("can not be done on zero address", async () => {
+      await expect(
+        batchedPhasedEscrow.connect(owner).approveBeneficiary(ZERO_ADDRESS)
+      ).to.be.revertedWith("Beneficiary can not be zero address")
+    })
+
+    it("emits an event", async () => {
+      const tx = await batchedPhasedEscrow
+        .connect(owner)
+        .approveBeneficiary(beneficiary1.address)
+
+      await expect(tx)
+        .to.emit(batchedPhasedEscrow, "BeneficiaryApproved")
+        .withArgs(beneficiary1.address)
+    })
+
+    it("maintains beneficiaries as non-approved by default", async () => {
+      expect(
+        await batchedPhasedEscrow.isBeneficiaryApproved(beneficiary1.address)
+      ).to.be.false
+      expect(
+        await batchedPhasedEscrow.isBeneficiaryApproved(beneficiary2.address)
+      ).to.be.false
+      expect(
+        await batchedPhasedEscrow.isBeneficiaryApproved(beneficiary3.address)
+      ).to.be.false
+    })
+
+    it("approves a single beneficiary", async () => {
+      await batchedPhasedEscrow
+        .connect(owner)
+        .approveBeneficiary(beneficiary2.address)
+
+      expect(
+        await batchedPhasedEscrow.isBeneficiaryApproved(beneficiary1.address)
+      ).to.be.false
+      expect(
+        await batchedPhasedEscrow.isBeneficiaryApproved(beneficiary2.address)
+      ).to.be.true
+      expect(
+        await batchedPhasedEscrow.isBeneficiaryApproved(beneficiary3.address)
+      ).to.be.false
+    })
+
+    it("approves multiple beneficiaries ", async () => {
+      await batchedPhasedEscrow
+        .connect(owner)
+        .approveBeneficiary(beneficiary1.address)
+      await batchedPhasedEscrow
+        .connect(owner)
+        .approveBeneficiary(beneficiary2.address)
+
+      expect(
+        await batchedPhasedEscrow.isBeneficiaryApproved(beneficiary1.address)
+      ).to.be.true
+      expect(
+        await batchedPhasedEscrow.isBeneficiaryApproved(beneficiary2.address)
+      ).to.be.true
+      expect(
+        await batchedPhasedEscrow.isBeneficiaryApproved(beneficiary3.address)
+      ).to.be.false
+    })
+  })
+
+  describe("drawee role", async () => {
+    it("is by default assigned to owner", async () => {
+      expect(await batchedPhasedEscrow.drawee()).to.equal(owner.address)
+    })
+
+    it("can be transferred by owner", async () => {
+      await batchedPhasedEscrow.connect(owner).setDrawee(updatedDrawee.address)
+      // ok, no revert
+    })
+
+    it("can be transferred by updated owner", async () => {
+      await batchedPhasedEscrow
+        .connect(owner)
+        .transferOwnership(updatedOwner.address)
+
+      await expect(
+        batchedPhasedEscrow.connect(owner).setDrawee(updatedDrawee.address)
+      ).to.be.revertedWith("Ownable: caller is not the owner")
+      await batchedPhasedEscrow
+        .connect(updatedOwner)
+        .setDrawee(updatedDrawee.address)
+      // ok, no revert
+    })
+
+    it("can not be transferred by non-owner", async () => {
+      await expect(
+        batchedPhasedEscrow.connect(drawee).setDrawee(updatedDrawee.address)
+      ).to.be.revertedWith("Ownable: caller is not the owner")
+    })
+
+    it("can be transferred to another account", async () => {
+      let tx = await batchedPhasedEscrow
+        .connect(owner)
+        .setDrawee(drawee.address)
+
+      expect(await batchedPhasedEscrow.drawee()).to.equal(drawee.address)
+      await expect(tx)
+        .to.emit(batchedPhasedEscrow, "DraweeRoleTransferred")
+        .withArgs(owner.address, drawee.address)
+
+      tx = await batchedPhasedEscrow
+        .connect(owner)
+        .setDrawee(updatedDrawee.address)
+
+      expect(await batchedPhasedEscrow.drawee()).to.equal(updatedDrawee.address)
+      await expect(tx)
+        .to.emit(batchedPhasedEscrow, "DraweeRoleTransferred")
+        .withArgs(drawee.address, updatedDrawee.address)
+    })
+  })
+
+  describe("batchedWithdraw", async () => {
+    let beneficiaries
+    let amounts
+    let escrowBalance
+
+    beforeEach(async () => {
+      beneficiaries = [
+        beneficiary1.address,
+        beneficiary2.address,
+        beneficiary3.address,
+      ]
+
+      amounts = [100, 200, 300]
+      escrowBalance = 600
+
+      await batchedPhasedEscrow
+        .connect(owner)
+        .approveBeneficiary(beneficiary1.address)
+      await batchedPhasedEscrow
+        .connect(owner)
+        .approveBeneficiary(beneficiary2.address)
+      await batchedPhasedEscrow
+        .connect(owner)
+        .approveBeneficiary(beneficiary3.address)
+
+      await batchedPhasedEscrow.connect(owner).setDrawee(drawee.address)
+
+      await token
+        .connect(tokenHolder)
+        .transfer(batchedPhasedEscrow.address, escrowBalance)
+    })
+
+    it("can be called by drawee", async () => {
+      await batchedPhasedEscrow
+        .connect(drawee)
+        .batchedWithdraw(beneficiaries, amounts)
+      // ok, no revert
+    })
+
+    it("can not be called by owner if not drawee", async () => {
+      await expect(
+        batchedPhasedEscrow
+          .connect(owner)
+          .batchedWithdraw(beneficiaries, amounts)
+      ).to.be.revertedWith("Caller is not the drawee")
+    })
+
+    it("can not be called by non-drawee", async () => {
+      await expect(
+        batchedPhasedEscrow
+          .connect(updatedDrawee)
+          .batchedWithdraw(beneficiaries, amounts)
+      ).to.be.revertedWith("Caller is not the drawee")
+    })
+
+    it("reverts when input arrays have different lengths", async () => {
+      await expect(
+        batchedPhasedEscrow
+          .connect(drawee)
+          .batchedWithdraw(beneficiaries, [100, 200])
+      ).to.be.revertedWith("Mismatched arrays length")
+    })
+
+    it("reverts when beneficiary is not IBeneficiaryContract", async () => {
+      await expect(
+        batchedPhasedEscrow
+          .connect(drawee)
+          .batchedWithdraw(
+            [beneficiary1.address, beneficiary2.address, owner],
+            amounts
+          )
+      ).to.be.reverted
+    })
+
+    it("reverts when beneficiary was not approved", async () => {
+      const TestSimpleBeneficiary = await ethers.getContractFactory(
+        "TestSimpleBeneficiary"
+      )
+      anotherBeneficiary = await TestSimpleBeneficiary.deploy()
+      await anotherBeneficiary.deployed()
+
+      await expect(
+        batchedPhasedEscrow
+          .connect(drawee)
+          .batchedWithdraw(
+            [beneficiary1.address, anotherBeneficiary.address],
+            [100, 200]
+          )
+      ).to.be.revertedWith("Beneficiary was not approved")
+    })
+
+    it("reverts when there are not enough funds in the escrow", async () => {
+      await expect(
+        batchedPhasedEscrow
+          .connect(drawee)
+          .batchedWithdraw(beneficiaries, [100, 200, 301])
+      ).to.be.reverted
+    })
+
+    it("withdraws specified tokens to beneficiaries", async () => {
+      await batchedPhasedEscrow
+        .connect(drawee)
+        .batchedWithdraw(beneficiaries, amounts)
+
+      for (let i = 0; i < beneficiaries.length; i++) {
+        expect(await token.balanceOf(beneficiaries[i])).to.equal(amounts[i])
+      }
+
+      expect(await token.balanceOf(batchedPhasedEscrow.address)).to.equal(0)
+    })
+  })
+})


### PR DESCRIPTION
Refs #220

[`BatchedPhasedEscrow`](https://github.com/keep-network/keep-core/blob/532021808f2fcf163d0f9727d9e73d8b002e81f9/solidity-v1/contracts/PhasedEscrow.sol#L81) was used by Keep Operations Team and is still used by Threshold Treasury Guild to distribute rewards to v1 KEEP Coverage Pool. It is a neat mechanism allowing to send tokens to the escrow every few months, and then allocate rewards every week, even from a separate address.

Since this mechanism is something the DAO is familiar with, we also want to use it for T Coverage Pool.

`BatchedPhasedEscrow` code lies in the archived `solidity-v1` directory of `keep-network/keep-core`.
Since we want to deploy a new instance of the `BatchedPhasedEscrow` for T token with T Coverage Pool as a beneficiary, the contract code has been copied **UNCHANGED** to this repository, not counting the changes from a separate commit of 4bdac20d789985ce61233c960254190d6cba92f6 needed to make the Slither happy. Unit tests also have been copied as-is, adjusting them to ethers framework used in this repository.

This PR does not configure deployment, it should be done in a separate PR.

