### PR TITLE
Configure git to don't use unauthenticated protocol

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -57,6 +57,15 @@ jobs:
           node-version: "14.x"
           cache: "yarn"
 
+      # This step forces Git to download dependencies using `https://` protocol,
+      # even if `yarn.json` refers to some package via `git://`. Using `git://`
+      # is no longer supported by GH. One of the `coverage-pools` dependencies
+      # by default uses `git://` and we needed to manually remove it every time
+      # it re-appeares in the lock file. Now even if it does re-appear, the
+      # `yarn install --frozen-lockfile` will not fail.
+      - name: Configure git to don't use unauthenticated protocol
+        run: git config --global url."https://".insteadOf git://
+
       - name: Install dependencies
         run: yarn install
 
@@ -75,6 +84,15 @@ jobs:
           node-version: "14.x"
           cache: "yarn"
           registry-url: "https://registry.npmjs.org"
+
+      # This step forces Git to download dependencies using `https://` protocol,
+      # even if `yarn.json` refers to some package via `git://`. Using `git://`
+      # is no longer supported by GH. One of the `coverage-pools` dependencies
+      # by default uses `git://` and we needed to manually remove it every time
+      # it re-appeares in the lock file. Now even if it does re-appear, the
+      # `yarn install --frozen-lockfile` will not fail.
+      - name: Configure git to don't use unauthenticated protocol
+        run: git config --global url."https://".insteadOf git://
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
@@ -156,6 +174,15 @@ jobs:
           node-version: "14.x"
           cache: "yarn"
 
+      # This step forces Git to download dependencies using `https://` protocol,
+      # even if `yarn.json` refers to some package via `git://`. Using `git://`
+      # is no longer supported by GH. One of the `coverage-pools` dependencies
+      # by default uses `git://` and we needed to manually remove it every time
+      # it re-appeares in the lock file. Now even if it does re-appear, the
+      # `yarn install --frozen-lockfile` will not fail.
+      - name: Configure git to don't use unauthenticated protocol
+        run: git config --global url."https://".insteadOf git://
+
       - name: Install needed dependencies
         run: yarn install --frozen-lockfile
 
@@ -185,6 +212,15 @@ jobs:
         with:
           node-version: "14.x"
           cache: "yarn"
+
+      # This step forces Git to download dependencies using `https://` protocol,
+      # even if `yarn.json` refers to some package via `git://`. Using `git://`
+      # is no longer supported by GH. One of the `coverage-pools` dependencies
+      # by default uses `git://` and we needed to manually remove it every time
+      # it re-appeares in the lock file. Now even if it does re-appear, the
+      # `yarn install --frozen-lockfile` will not fail.
+      - name: Configure git to don't use unauthenticated protocol
+        run: git config --global url."https://".insteadOf git://
 
       - name: Install dependencies
         run: yarn install

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -18,6 +18,13 @@ jobs:
           node-version: "14"
           cache: "yarn"
 
+      # This step forces Git to download dependencies using `https://` protocol,
+      # even if `yarn.json` refers to some package via `git://`. Using `git://`
+      # is no longer supported by GH. One of the `coverage-pools` dependencies
+      # by default uses `git://` and we needed to manually remove it every time
+      # it re-appeares in the lock file. Now even if it does re-appear, the
+      # `yarn install --frozen-lockfile` will not fail.
+
       - name: Install dependencies
         run: yarn install
 

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -24,6 +24,15 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           cache: "yarn"
 
+      # This step forces Git to download dependencies using `https://` protocol,
+      # even if `yarn.json` refers to some package via `git://`. Using `git://`
+      # is no longer supported by GH. One of the `coverage-pools` dependencies
+      # by default uses `git://` and we needed to manually remove it every time
+      # it re-appeares in the lock file. Now even if it does re-appear, the
+      # `yarn install --frozen-lockfile` will not fail.
+      - name: Configure git to don't use unauthenticated protocol
+        run: git config --global url."https://".insteadOf git://
+
       - name: Resolve latest contracts
         run: |
           yarn upgrade \

--- a/README.adoc
+++ b/README.adoc
@@ -91,6 +91,18 @@ yarn build
 ```
 Compiled contracts will land in the `build/` directory.
 
+*NOTE:* The `coverage-pools` package contains an indirect dependency to
+`@summa-tx/relay-sol@2.0.2` package, which downloads one of its sub-dependencies
+via unathenticated `git://` protocol. That protocol is no longer supported by
+GitHub. This means that in certain situations installation of the package or
+update of its dependencies using Yarn may result in `The unauthenticated git
+protocol on port 9418 is no longer supported` or `unable to connect to
+github.com` error. +
+As a workaround, we advise changing Git configuration to use `https://` protocol
+instead of `git://` by executing:
+```
+git config --global url."https://".insteadOf git://
+
 === Test contracts
 
 There are multiple test scenarios living in the `test` directory.


### PR DESCRIPTION
This step forces Git to download dependencies using `https://` protocol, even if `yarn.lock` refers to some package via `git://`. Using `git://` is no longer supported by GH. One of the `coverage-pools` dependencies by default uses `git://` and we needed to manually remove it every time it re-appeares in the lock file. Now even if it does re-appear, the `yarn install --frozen-lockfile` or `yarn install` will not fail.