### PR TITLE
Update dependencies to `solidity-contracts`

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1904,9 +1904,9 @@
     "@openzeppelin/contracts" "^4.1.0"
 
 "@threshold-network/solidity-contracts@development":
-  version "1.3.0-dev.3"
-  resolved "https://registry.yarnpkg.com/@threshold-network/solidity-contracts/-/solidity-contracts-1.3.0-dev.3.tgz#aa896b80a083ca8a7cb5219e3c9d1c47e3d86b03"
-  integrity sha512-BNm5+JKrFvg9hZ02Sp/A+vKs1PQB37rYdcZqLrLhvwDFzHFvL+XA2IXqvN1CznQTeehwnX3DtCcONTVP42i56A==
+  version "1.3.0-dev.5"
+  resolved "https://registry.yarnpkg.com/@threshold-network/solidity-contracts/-/solidity-contracts-1.3.0-dev.5.tgz#f7a2727d627a10218f0667bc0d33e19ed8f87fdc"
+  integrity sha512-AInTKQkJ0PKa32q2m8GnZFPYEArsnvOwhIFdBFaHdq9r4EGyqHMf4YY1WjffkheBZ7AQ0DNA8Lst30kBoQd0SA==
   dependencies:
     "@keep-network/keep-core" ">1.8.1-dev <1.8.1-goerli"
     "@openzeppelin/contracts" "~4.5.0"


### PR DESCRIPTION
We have published new `@threshold-network/solidity-contract` package. This package no longer includes the `prepare-dependencies.sh` script which was causing random failures during `yarn install`. As in some CI jobs we install the dependencies based on the lockfile (with the `--frozen-lockfile` flag), we need to update the dependencies in the lockfile so that the new, improved packages would be used.

Refs:
https://github.com/threshold-network/solidity-contracts/issues/142
https://github.com/threshold-network/token-dashboard/pull/533
https://github.com/keep-network/keep-core/pull/3618
https://github.com/keep-network/tbtc-v2/pull/631