### PR TITLE
Support deployment on Sepolia

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -10,9 +10,8 @@ on:
   workflow_dispatch:
     inputs:
       environment:
-        description: "Environment for workflow execution"
-        required: false
-        default: "dev"
+        description: "Environment (network) for workflow execution, e.g. `sepolia`"
+        required: true
       upstream_builds:
         description: "Upstream builds"
         required: false
@@ -25,9 +24,9 @@ jobs:
   contracts-build-and-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "14.x"
           cache: "yarn"
@@ -50,9 +49,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name != 'schedule'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "14.x"
           cache: "yarn"
@@ -77,9 +76,9 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "14.x"
           cache: "yarn"
@@ -98,30 +97,33 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Get upstream packages' versions
-        uses: keep-network/ci/actions/upstream-builds-query@v1
+        uses: keep-network/ci/actions/upstream-builds-query@v2
         id: upstream-builds-query
         with:
           upstream-builds: ${{ github.event.inputs.upstream_builds }}
           query: |
+            threshold-contracts-version = github.com/threshold-network/solidity-contracts#version
             keep-core-contracts-version = github.com/keep-network/keep-core/solidity-v1#version
             tbtc-contracts-version = github.com/keep-network/tbtc/solidity#version
 
       - name: Resolve latest contracts
         run: |
           yarn upgrade \
-            @keep-network/keep-core@${{ steps.upstream-builds-query.outputs.keep-core-contracts-version }} \
-            @keep-network/tbtc@${{ steps.upstream-builds-query.outputs.tbtc-contracts-version }}
-
-      - name: Configure tenderly
-        if: github.event.inputs.environment == 'ropsten'
-        env:
-          TENDERLY_TOKEN: ${{ secrets.TENDERLY_TOKEN }}
-        run: ./config_tenderly.sh
+            @threshold-network/solidity-contracts@${{ steps.upstream-builds-query.outputs.threshold-contracts-version }} \
+            @keep-network/keep-core@${{ github.event.inputs.environment }} \
+            @keep-network/tbtc@${{ github.event.inputs.environment }}
 
       - name: Deploy contracts
         env:
-          CHAIN_API_URL: ${{ secrets.KEEP_TEST_ETH_HOSTNAME_HTTP }}
-          CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: ${{ secrets.KEEP_TEST_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
+          # Using fake ternary expression to decide which credentials to use,
+          # depending on chosen environment. Note: if `GOERLI_ETH_HOSTNAME_HTTP`
+          # is empty, the expression will be evaluated to
+          # `SEPOLIA_ETH_HOSTNAME_HTTP`'s value.
+          CHAIN_API_URL: |
+            ${{ inputs.github.event.inputs.environment == 'goerli'
+              && secrets.GOERLI_ETH_HOSTNAME_HTTP
+              || secrets.SEPOLIA_ETH_HOSTNAME_HTTP }}
+          ACCOUNTS_PRIVATE_KEYS: ${{ secrets.TESTNET_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
         run: yarn deploy --network ${{ github.event.inputs.environment }}
 
       - name: Bump up package version
@@ -135,10 +137,10 @@ jobs:
       - name: Publish to npm
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access=public --network=${{ github.event.inputs.environment }} --tag ${{ github.event.inputs.environment }}
+        run: npm publish --access=public --tag ${{ github.event.inputs.environment }} --network=${{ github.event.inputs.environment }}
 
       - name: Notify CI about completion of the workflow
-        uses: keep-network/ci/actions/notify-workflow-completed@v1
+        uses: keep-network/ci/actions/notify-workflow-completed@v2
         env:
           GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:
@@ -149,66 +151,15 @@ jobs:
           upstream_ref: ${{ github.event.inputs.upstream_ref }}
           version: ${{ steps.npm-version-bump.outputs.version }}
 
-      - name: Upload files needed for etherscan verification
-        uses: actions/upload-artifact@v2
-        with:
-          name: Artifacts for etherscan verifcation
-          path: |
-            ./deployments
-            ./package.json
-            ./yarn.lock
-
-  contracts-etherscan-verification:
-    needs: [contracts-deployment-testnet]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Download files needed for etherscan verification
-        uses: actions/download-artifact@v2
-        with:
-          name: Artifacts for etherscan verifcation
-
-      - uses: actions/setup-node@v2
-        with:
-          node-version: "14.x"
-          cache: "yarn"
-
-      # This step forces Git to download dependencies using `https://` protocol,
-      # even if `yarn.json` refers to some package via `git://`. Using `git://`
-      # is no longer supported by GH. One of the `coverage-pools` dependencies
-      # by default uses `git://` and we needed to manually remove it every time
-      # it re-appeares in the lock file. Now even if it does re-appear, the
-      # `yarn install --frozen-lockfile` will not fail.
-      - name: Configure git to don't use unauthenticated protocol
-        run: git config --global url."https://".insteadOf git://
-
-      - name: Install needed dependencies
-        run: yarn install --frozen-lockfile
-
-      # If we don't remove the dependencies' contracts from `node-modules`, the
-      # `etherscan-verify` plugins tries to verify them, which is not desired.
-      - name: Prepare for verification on Etherscan
-        run: |
-          rm -rf ./node_modules/@keep-network/keep-core
-          rm -rf ./node_modules/@keep-network/tbtc
-          rm -rf ./node_modules/@threshold-network/solidity-contracts
-
-      - name: Verify contracts on Etherscan
-        env:
-          ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
-          CHAIN_API_URL: ${{ secrets.KEEP_TEST_ETH_HOSTNAME_HTTP }}
-        run: yarn run hardhat --network ${{ github.event.inputs.environment }} etherscan-verify --license MIT
-
   contracts-lint:
     runs-on: ubuntu-latest
     if: |
       github.event_name != 'workflow_dispatch'
         && github.event_name != 'schedule'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "14.x"
           cache: "yarn"
@@ -234,14 +185,14 @@ jobs:
       github.event_name != 'workflow_dispatch'
         && github.event_name != 'schedule'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "14.x"
           cache: "yarn"
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.10.8
 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -11,9 +11,9 @@ jobs:
   code-format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "14"
           cache: "yarn"
@@ -24,6 +24,8 @@ jobs:
       # by default uses `git://` and we needed to manually remove it every time
       # it re-appeares in the lock file. Now even if it does re-appear, the
       # `yarn install --frozen-lockfile` will not fail.
+      - name: Configure git to don't use unauthenticated protocol
+        run: git config --global url."https://".insteadOf git://
 
       - name: Install dependencies
         run: yarn install

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -16,9 +16,9 @@ jobs:
   npm-compile-publish-contracts:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "14.x"
           registry-url: "https://registry.npmjs.org"

--- a/.hardhat/networks_TEMPLATE.ts
+++ b/.hardhat/networks_TEMPLATE.ts
@@ -7,7 +7,7 @@ import { LocalNetworksConfig } from "@keep-network/hardhat-local-networks-config
 
 const config: LocalNetworksConfig = {
   networks: {
-    ropsten: {
+    sepolia: {
       url: "url not set",
       from: "address not set",
       accounts: ["private key not set"],

--- a/README.adoc
+++ b/README.adoc
@@ -130,7 +130,7 @@ code as it contains deployment details like chain ID, transaction hash, ABI or
 address for each contract.
 
 The `deployments/` directory contains a separate sub-directory for each network, e.g.
-`deployments/ropsten/`, `deployments/mainnet/`. For a convenient usage of the
+`deployments/sepolia/`, `deployments/mainnet/`. For a convenient usage of the
 package we publish the deployment artifacts in a separate package for every
 network. The package contains deployment artifacts under `artifacts/` directory,
 which is a a copy of `deployments/<network>/` directory.
@@ -229,7 +229,7 @@ Example:
     ],
     deployments: {
       // ...
-      ropsten: [
+      sepolia: [
          // ...
         "node_modules/@keep-network/keep-core/artifacts",
       ],
@@ -246,7 +246,7 @@ To add a predefined single contract dependency for a given network:
 
 1. Create a file under `external/<network>/<contract_name>.json`.
 +
-Example: `external/ropsten/UniswapV2Router.json`
+Example: `external/sepolia/UniswapV2Router.json`
 
 2. Save an address and optionally an ABI for the contract in the file.
 +
@@ -270,9 +270,9 @@ Example:
   external: {
     deployments: {
       // ...
-      ropsten: [
+      sepolia: [
          // ...
-        "./external/ropsten",
+        "./external/sepolia",
       ],
     },
   },

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -52,13 +52,13 @@ const config: HardhatUserConfig = {
         : undefined,
       tags: ["etherscan", "tenderly"],
     },
-    ropsten: {
+    sepolia: {
       url: process.env.CHAIN_API_URL || "",
-      chainId: 3,
-      accounts: process.env.CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY
-        ? [process.env.CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY]
+      chainId: 11155111,
+      accounts: process.env.ACCOUNTS_PRIVATE_KEYS
+        ? process.env.ACCOUNTS_PRIVATE_KEYS.split(",")
         : undefined,
-      tags: ["tenderly"],
+      tags: ["etherscan", "tenderly"],
     },
     mainnet: {
       url: process.env.CHAIN_API_URL || "",
@@ -79,6 +79,10 @@ const config: HardhatUserConfig = {
   external: {
     contracts: [
       {
+        artifacts:
+          "node_modules/@threshold-network/solidity-contracts/artifacts",
+      },
+      {
         artifacts: "node_modules/@keep-network/keep-core/artifacts",
         // Example if we want to use deployment scripts from external package:
         // deploy: "node_modules/@keep-network/keep-core/deploy",
@@ -94,13 +98,21 @@ const config: HardhatUserConfig = {
       // For development environment we expect the local dependencies to be linked
       // with `yarn link` command.
       development: [
+        "node_modules/@threshold-network/solidity-contracts/artifacts",
         "node_modules/@keep-network/keep-core/artifacts",
         "node_modules/@keep-network/tbtc/artifacts",
       ],
-      ropsten: [
+      goerli: [
+        "node_modules/@threshold-network/solidity-contracts/artifacts",
         "node_modules/@keep-network/keep-core/artifacts",
         "node_modules/@keep-network/tbtc/artifacts",
-        "./external/ropsten",
+        "./external/goerli",
+      ],
+      sepolia: [
+        "node_modules/@threshold-network/solidity-contracts/artifacts",
+        "node_modules/@keep-network/keep-core/artifacts",
+        "node_modules/@keep-network/tbtc/artifacts",
+        "./external/sepolia",
       ],
       mainnet: ["./external/mainnet-v2"],
     },
@@ -112,17 +124,19 @@ const config: HardhatUserConfig = {
     rewardManager: {
       default: 1,
       goerli: 0, // use deployer account
-      ropsten: 0, // use deployer account
+      sepolia: 0, // use deployer account
       mainnet: 0, // use deployer account
     },
     thresholdCouncil: {
       default: 2,
       goerli: 0, // use deployer account
+      sepolia: 0, // use deployer account
       mainnet: "0x9f6e831c8f8939dc0c830c6e492e7cef4f9c2f5f",
     },
     treasuryGuild: {
       default: 3,
       goerli: 0, // use deployer account
+      sepolia: 0, // use deployer account
       mainnet: "0x71E47a4429d35827e0312AA13162197C23287546",
     },
   },

--- a/tenderly.yaml
+++ b/tenderly.yaml
@@ -1,3 +1,6 @@
+# This file is currently being ignored by the `hardhat-tenderly` plugin. There
+# is an open feature request to make it supported:
+# https://github.com/Tenderly/hardhat-tenderly/issues/17.
 account_id: d9a948cf-8667-43df-acb0-ce194f6dda7a
 projects:
   thesis/keep:
@@ -5,4 +8,4 @@ projects:
       - "1" # mainnet
   thesis/keep-test:
     networks:
-      - "3" # ropsten
+      - "11155111" # sepolia


### PR DESCRIPTION
The Görli testnet currently used by Threshold/Keep for development purposes is planned to become deprecated with the end of year 2023. The testnet that was created to replace it is called
[Holešky](https://github.com/eth-clients/holesky), however it will take some time until it gets integrated with by some of the projects we rely on. As a solution, we decided to switch first to another testnet that is currently live - Sepolia. This testnet's EOL is planned for 2026, which gives us plenty of time to move to Holešky before Sepolia gets deprecated. Until Görli is not dead we want to support both testnets, which is what we did in some of the projects already. In `coverage-pools` however we were missing some Görli configuration. So for now, for consistency between projects, we've added the missing part for Görli support and also added full support of Sepolia testnet.
Some other changes:
- we've removed the `contracts-etherscan-verification` job from CI (it was needed when `hardhat-deploy` was used to verify contracts, but in https://github.com/threshold-network/solidity-contracts/pull/125 we switched to using `@nomiclabs/hardhat-etherscan` plugin
- we've updated the versions of some of the actions used in our CI, as the previously set versions were running on `node14` which will be no longer supported by GH at some point in the future