### PR TITLE
Update actions to versions running on Node20

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -24,9 +24,9 @@ jobs:
   contracts-build-and-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: "14.x"
           cache: "yarn"
@@ -49,9 +49,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name != 'schedule'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: "14.x"
           cache: "yarn"
@@ -76,9 +76,9 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: "14.x"
           cache: "yarn"
@@ -157,9 +157,9 @@ jobs:
       github.event_name != 'workflow_dispatch'
         && github.event_name != 'schedule'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: "14.x"
           cache: "yarn"
@@ -185,14 +185,14 @@ jobs:
       github.event_name != 'workflow_dispatch'
         && github.event_name != 'schedule'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: "14.x"
           cache: "yarn"
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.10.8
 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -11,9 +11,9 @@ jobs:
   code-format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: "14"
           cache: "yarn"

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -16,9 +16,9 @@ jobs:
   npm-compile-publish-contracts:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: "14.x"
           registry-url: "https://registry.npmjs.org"


### PR DESCRIPTION
As per
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/, GitHub has started a deprecation process for the GitHub Actions that run on Node16. We're updating Actions that use this version of Node to newer versions, running on Node20.